### PR TITLE
Fix GH-61 + GH-62: graceful storyboard validate fallback & README quickstart deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Automated pipeline for extracting, analyzing, publishing, and storyboarding YouT
 
 ## Quick Start
 
+> **First-time setup:** Install Python deps with `./scripts/setup_deps.sh --dev`.
+> All Python invocations below use `./scripts/run.sh` so the vendored `.deps/`
+> directory is on `PYTHONPATH`. (A traditional `python -m venv .venv && pip install -r requirements.txt`
+> also works — drop the `./scripts/run.sh` prefix and use `python` directly if you go that route.)
+
 ```bash
+# 0. One-time: install Python dependencies into vendored .deps/
+./scripts/setup_deps.sh --dev
+
 # 1. Start pipeline server (serves Chrome extension)
 cd pipeline-server && node server.js
 
@@ -19,10 +27,10 @@ npx ts-node src/index.ts "https://youtube.com/watch?v=VIDEO_ID" 1.0 --output ../
 # 3. Analyze scenes (Python)
 cd /path/to/airtable-shots-db
 set -a && source .env && set +a
-python -m analyzer --capture-dir captures/VIDEO_ID_*/ --verbose
+./scripts/run.sh -m analyzer --capture-dir captures/VIDEO_ID_*/ --verbose
 
 # 4. Publish to Airtable + R2 (with Frames)
-python -m publisher \
+./scripts/run.sh -m publisher \
   --capture-dir captures/VIDEO_ID_*/ \
   --api-key "$AIRTABLE_API_KEY" \
   --base-id "$AIRTABLE_BASE_ID" \
@@ -32,7 +40,7 @@ python -m publisher \
   --verbose
 
 # 5. Optional: publish with shot enrichment
-python -m publisher \
+./scripts/run.sh -m publisher \
   --capture-dir captures/VIDEO_ID_*/ \
   --api-key "$AIRTABLE_API_KEY" \
   --base-id "$AIRTABLE_BASE_ID" \
@@ -42,7 +50,7 @@ python -m publisher \
   --verbose
 
 # 6. Optional: enrich with Gemini instead of Ollama
-python -m publisher \
+./scripts/run.sh -m publisher \
   --capture-dir captures/VIDEO_ID_*/ \
   --api-key "$AIRTABLE_API_KEY" \
   --base-id "$AIRTABLE_BASE_ID" \
@@ -54,14 +62,14 @@ python -m publisher \
   --verbose
 
 # 7. A/B test model comparison (Ollama vs Gemini)
-python scripts/ab_enrichment_test.py \
+./scripts/run.sh scripts/ab_enrichment_test.py \
   --capture-dir captures/VIDEO_ID_*/ \
   --models llava:latest gemini:gemini-2.5-flash \
   --max-frames 4 \
   --show-details
 
 # 8. Generate storyboard panels (dry-run)
-python scripts/validate_storyboard_handoff.py \
+./scripts/run.sh scripts/validate_storyboard_handoff.py \
   --video-id VIDEO_ID --shot-label S01 --dry-run
 ```
 

--- a/scripts/validate_storyboard_handoff.py
+++ b/scripts/validate_storyboard_handoff.py
@@ -200,20 +200,25 @@ def main():
         ]
         if args.shot_id:
             records = [r for r in records if r.get("id") == args.shot_id]
-    
-    # Filter by shot label if specified
-    if args.shot_label:
-        records = [
-            r for r in records
-            if r.get("fields", {}).get("Shot Label") == args.shot_label
-        ]
     else:
-        # Backward-compatible fallback: attempt the original filter.
+        # Backward-compatible fallback: attempt the original filter when the
+        # video_id could not be resolved to a Videos record.
+        print(
+            f"Could not resolve a Videos record for video_id={args.video_id!r}; "
+            "falling back to legacy fetch_enriched_shots_for_storyboard()."
+        )
         records = fetch_enriched_shots_for_storyboard(
             shots_table,
             video_id=args.video_id,
             shot_id=args.shot_id,
         )
+
+    # Optional shot-label filter composes with whichever fetch path ran above.
+    if args.shot_label:
+        records = [
+            r for r in records
+            if r.get("fields", {}).get("Shot Label") == args.shot_label
+        ]
 
     if not records:
         print("\nNo enriched shots found. Run enrichment first.")


### PR DESCRIPTION
Closes #61
Closes #62

## #61 — `validate_storyboard_handoff.py` UnboundLocalError

Repro before fix:

```
$ ./scripts/run.sh scripts/validate_storyboard_handoff.py --video-id VIDEO_ID --shot-label S01 --dry-run
...
UnboundLocalError: cannot access local variable 'records' where it is not associated with a value
```

Root cause: `records` was only assigned inside `if video_record_id:`. When the Videos lookup returned nothing, the next `if args.shot_label:` block referenced `records` before assignment. The legacy fallback only ran in the `else` of `shot_label`, so users passing `--shot-label` got no fallback either.

Fix: move the legacy `fetch_enriched_shots_for_storyboard()` fallback into the `else` of `if video_record_id:` so `records` is always assigned, and run the `--shot-label` filter unconditionally as a follow-on step.

After fix:

```
$ ./scripts/run.sh scripts/validate_storyboard_handoff.py --video-id NONEXISTENT_VIDEO --shot-label S01 --dry-run
Could not resolve a Videos record for video_id='NONEXISTENT_VIDEO'; falling back to legacy fetch_enriched_shots_for_storyboard().
No enriched shots found. Run enrichment first.
$ echo $?
0
```

## #62 — README Quick Start fails on fresh clone

The Quick Start told users to run bare `python -m analyzer ...`, but a fresh clone has no `.venv` and no `.deps/`, so it failed with `ModuleNotFoundError: No module named 'dotenv'`.

Fix: prepend step `0. ./scripts/setup_deps.sh --dev` and switch all Python invocations in Quick Start to `./scripts/run.sh ...` (consistent with the rest of the README). Documented the traditional venv flow as an alternative.

## Verification

- Manual: ran fixed script with bogus video id → exits 0 with friendly message instead of crashing.
- README diff is docs-only; no test coverage needed.