### PR TITLE
feat(normalizer): capture metrics + repurposing fields, add Airtable-driven batch sweeps

### DIFF
--- a/.claude/skills/apify-harvest/SKILL.md
+++ b/.claude/skills/apify-harvest/SKILL.md
@@ -6,11 +6,15 @@ description: Run a bounded YouTube channel sweep into Airtable via the Apify nor
 # Harvest a YouTube channel into Airtable
 
 Runs `normalizer/apify-harvest.js` (Apify `streamers/youtube-scraper` → Airtable Videos). Proven end
-to end 2026-07-29; the verification table is in `docs/NORMALIZER-MANIFEST.md`.
+to end 2026-07-29, extended to metrics + batch sweeps 2026-07-30; verification tables are in
+`docs/NORMALIZER-MANIFEST.md`.
 
-**Costs real money** — pay-per-event, roughly $0.004/video. Always dry-run first.
+**Costs real money** — pay-per-event, roughly $0.004/video, and **a `--dry-run` still runs the actor**,
+so it costs the same as a real run. Dry-run is for checking the payload, not for saving money.
 
 ## Run it
+
+One channel:
 
 ```bash
 cd normalizer && npm test && node apify-harvest.js \
@@ -18,12 +22,22 @@ cd normalizer && npm test && node apify-harvest.js \
   --max-results 5 --oldest-post-date 2026-07-01 --dry-run
 ```
 
-Drop `--dry-run` only after the printed payload looks right. `--save-raw <path>` dumps the raw
-dataset — use it whenever the output shape matters.
+Every channel with `Harvest?` ticked in Airtable (uses each row's `Source URL`):
 
-`--max-results` and `--oldest-post-date` are **mandatory by design**, dry-run or not. Do not add a
-bypass. `oldestPostDate` is verified honored (negative control 2026-07-29), and it accepts relative
-values like `"7 days"`.
+```bash
+cd normalizer && node apify-harvest.js --from-airtable --max-results 5 --oldest-post-date "30 days"
+```
+
+Drop `--dry-run` only after the printed payload looks right. `--save-raw <path>` dumps the raw
+dataset — use it whenever the output shape matters (in batch mode it writes one file per channel).
+
+`--max-results` and `--oldest-post-date` are **mandatory by design** in both modes, dry-run or not.
+Do not add a bypass, and be especially wary of loosening them for `--from-airtable` — batch
+multiplies the cost by the number of ticked channels. `oldestPostDate` is verified honored
+(negative control 2026-07-29) and accepts relative values like `"7 days"`.
+
+**To add a channel to the sweep, tick `Harvest?` and set `Source URL` in Airtable — never edit a
+list in the repo.** That is the whole point of the config living in the base.
 
 ## Non-negotiables
 
@@ -42,7 +56,14 @@ values like `"7 days"`.
    silently gain a fresh transcript on a re-sweep — that's correct, and worth a human glance.
 5. **Adding a new `Transcript Source` value needs an Airtable UI edit.** The API cannot add
    singleSelect choices, and a mismatched value 422s the *entire* record. A dry-run cannot catch it
-   — it performs no writes.
+   — it performs no writes. Same for a brand-new field: it must exist in the base *before* anything
+   writes to it. And never put an actor-supplied value (a hashtag, a category) into a select — we
+   control our provenance slugs, we do not control what YouTube returns.
+6. **Never touch `Track` on an existing Channel.** `upsertChannel` PATCHes stats onto existing rows
+   now; `Track` is human-owned routing, the Channels analogue of `Triage Status`. Clobbering it
+   drops the channel out of the working view *without erroring*.
+7. **Metrics are a snapshot, not history.** A re-sweep overwrites `View Count` and friends in place
+   and re-stamps `Metrics Captured At`. Quote a metric with its capture date, or not at all.
 
 ## When a run reports errors
 
@@ -57,7 +78,12 @@ Per-item failures are isolated: the run continues and exits non-zero. Read the `
 - **429 / rate limit** — there is no retry/backoff (deliberate, documented non-goal). Airtable caps
   at 5 req/s. Re-run; the upsert is idempotent, so it will update rather than duplicate.
 - **Queue ceiling refusal** — working as intended. The bottleneck is the human review gate, not
-  capture. Clear the queue instead of raising `--queue-ceiling`.
+  capture. Clear the queue instead of raising `--queue-ceiling`. In `--from-airtable` mode the
+  ceiling is re-checked before *each* channel, so a batch can stop partway; it names the unswept
+  channels and exits 1. Re-running after clearing the queue picks them up — the upsert is
+  idempotent, so already-swept channels just report `updated`.
+- **`Harvest? is ticked but Source URL is blank`** — a config mistake, not a failure. The run skips
+  that channel and continues. Fill in `Source URL` (the `@handle` page form).
 
 ## Don't
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,16 +7,21 @@ project, `~/claude/Youtube Transcripts`) can turn them into teardowns, digests a
 
 This repo owns **capture only**. Triage, treatment, and everything downstream lives in the refinery.
 
-## Current state — 2026-07-29
+## Current state — 2026-07-30
 
-**Capture is pivoting from browser automation to a hosted scraper.** Five months of work proved that
-the transcript can be *extracted* reliably but not *delivered* reliably without a human clicking. The
-decision record and the full evidence are in `docs/archive/FINDINGS-youtube-automation.md` — **read
-§1 before proposing any change to the capture mechanism.**
+**The pivot from browser automation to a hosted scraper is complete.** Five months of work proved
+that the transcript can be *extracted* reliably but not *delivered* reliably without a human
+clicking. The decision record and the full evidence are in
+`docs/archive/FINDINGS-youtube-automation.md` — **read §1 before proposing any change to the capture
+mechanism.**
+
+Capture is no longer the constraint. Unattended batch sweeps run on one command, and the binding
+limit is now the **human review gate** downstream in the refinery. Read that as: the useful work
+left in this repo is mostly *not* "capture more," it's making what's captured easier to triage.
 
 | Path | Status |
 |------|--------|
-| Apify `streamers/youtube-scraper` (`h7sDV53CddomktSi5`) | **Primary — working end to end**, verified live 2026-07-29 (branch `feat/apify-normalizer`) |
+| Apify `streamers/youtube-scraper` (`h7sDV53CddomktSi5`) | **Primary — working end to end**, verified live 2026-07-29, extended to metrics + batch sweeps 2026-07-30 (branch `feat/metrics-fields`) |
 | Chrome extension (`chrome-extension/`) | **Frozen fallback** — works, no further investment |
 | YouTube Data API v3 | Permanently closed — ownership dealbreaker |
 | Direct HTTP / `timedtext` from our own IP | Permanently closed — 429 `IpBlocked` |
@@ -31,25 +36,42 @@ GUI automation) and B (direct HTTP) are closed.
 **The extension stays loaded and working.** It's the right tool for "this one video, right now, no
 cost." It is not the right tool for unattended volume, and it should not be developed further.
 
-## Active work — Apify → Airtable normalizer `[working; proven live 2026-07-29]`
+## Active work — Apify → Airtable normalizer `[working; proven live 2026-07-30]`
 
-Run it: `cd normalizer && node apify-harvest.js --channel-url <url> --max-results <n>
---oldest-post-date <YYYY-MM-DD> [--dry-run] [--save-raw <path>]`. `--max-results` and
-`--oldest-post-date` are mandatory by design. Details and the live verification table:
-`docs/NORMALIZER-MANIFEST.md`.
+Run it, one channel:
+
+```
+cd normalizer && node apify-harvest.js --channel-url <url> --max-results <n> \
+  --oldest-post-date <YYYY-MM-DD> [--dry-run] [--save-raw <path>]
+```
+
+Or sweep every Channel with `Harvest?` ticked, using its `Source URL`:
+
+```
+cd normalizer && node apify-harvest.js --from-airtable --max-results <n> --oldest-post-date "30 days"
+```
+
+`--max-results` and `--oldest-post-date` are mandatory by design **in both modes** — batch
+multiplies the cost by the channel count, so it needs more bounding, not less. Details and the live
+verification tables: `docs/NORMALIZER-MANIFEST.md`.
 
 ```
 Airtable Channels (Harvest? · Source URL · Last harvested · Track)
-        ↓ read config, check Queued-count ceiling
+        ↓ read config, re-check Queued-count ceiling BEFORE EACH CHANNEL
 Apify run: startUrls + oldestPostDate + maxResults + downloadSubtitles
         ↓ dataset
-Normalizer (this repo, Node — reuses lib/transcript-utils.js)
+Normalizer (this repo, Node — reuses chrome-extension/lib/transcript-utils.js)
    parse subtitles → {text,start} · find-or-create Channel · upsert by Video ID
+   metrics + description + links → updateFields · channel stats → Channels
         ↓
 Videos: Triage Status=Queued · Intake Source=Sweep · Track via Channel link
         ↓ unchanged
 AIHS refinery: triage → teardown/digest → Ideas → human review gate
 ```
+
+The ceiling is re-checked **per channel**, not once per run: a single up-front check would let one
+verdict wave ten channels through, which is a guardrail that stops guarding exactly when volume
+arrives.
 
 Decisions already made (2026-07-29):
 
@@ -59,21 +81,34 @@ Decisions already made (2026-07-29):
   and adding a channel shouldn't need a commit.
 - Ship a `--dry-run` that prints intended writes and touches nothing, **before** it ever writes.
 
-Guardrails agreed for first run, because removing capture friction removes the accidental throttle on
-intake (the refinery's real bottleneck is a human review gate):
+Guardrails, because removing capture friction removes the accidental throttle on intake (the
+refinery's real bottleneck is a human review gate). All shipped except the last:
 
-- `maxResults` **and** a date filter mandatory on every run. No unbounded channel pulls.
-- `Intake Source` field on Videos — distinguish hand-curated (Watch Later) from swept, so triage can
-  be stricter on sweeps.
-- A **Track-unset** triage view. Bulk ingest creates Channels with blank `Track`, and the refinery's
-  working view filters `Track = AIHS OR Tooling-watch` — so blank-Track videos vanish *silently*
-  rather than failing loudly.
-- A queue-depth ceiling: refuse to harvest while `Queued` is above threshold.
+- ✅ `maxResults` **and** a date filter mandatory on every run, both modes. No unbounded pulls.
+- ✅ `Intake Source` on Videos — hand-curated (`Watch Later`) vs swept (`Sweep`), so triage can be
+  stricter on sweeps. Everything triaged before 2026-07-30 was hand-picked; that's no longer true.
+- ✅ Queue-depth ceiling, **re-checked before each channel** in batch mode.
+- ⬜ A **Track-unset** view on Channels. Bulk ingest creates Channels with blank `Track`, and the
+  refinery's working view filters `Track = AIHS OR Tooling-watch` — so blank-Track videos vanish
+  *silently* rather than failing loudly. **4 of 88 Channels** are currently blank
+  (`@Jasper_Tech`, `@BulbDigital`, `@3.7Million`, `@WizardsandWarriors`). Manual UI step — the
+  Airtable MCP has no create-view tool.
 
-**Next step is cheap and comes first:** one manual Apify run against a single channel with
-`maxResults: 5` (~$0.02) to read the *actual* dataset shape. The design above assumes an output
-contract inferred from a schema, not observed from a real item — which is the same class of mistake as
-trusting `data-save-state` over the Airtable write.
+### Where things stand, and what's actually next
+
+Live counts as of 2026-07-30: **106 Videos** (16 `Queued`, ceiling 30), **88 Channels**, 5 with
+`Harvest?` ticked (`@WayneStLedger`, `@M365CopilotConnection`, `@MicrosoftCommunityLearning`,
+`@KevinStratvert`, `@your365coach`).
+
+1. **Triage the 16 Queued** before sweeping more — the ceiling will halt a batch partway at 30, by
+   design. This is the bottleneck; adding capture volume against it is the one move that makes
+   things worse.
+2. **Commit `feat/metrics-fields`** — the metrics/batch work is verified live but was left
+   uncommitted.
+3. Build the Track-unset view (above).
+4. Decide unattended invocation — cron, a scheduled task, or stay manual. `--from-airtable` makes
+   this a single command with no channel list baked into the repo, so nothing blocks it technically.
+   The question is whether *capture* should be automated while triage isn't.
 
 Actor input keys (verified 2026-07-29 against the published schema and two live channel-mode runs):
 `startUrls`, `maxResults`, `maxResultsShorts`, `maxResultStreams`, `oldestPostDate`, `dateFilter`,
@@ -98,7 +133,15 @@ correction.
   `Triage Status` (default Queued), `Thumbnail URL`, `Thumbnail (Image)`, `Transcript (Full)`,
   `Transcript (Timestamped)` (JSON array of `{text, start}`), `Transcript Language`,
   `Transcript Source`, `Channel` (link)
+  - **Metrics/repurposing (added 2026-07-30)** — `Published At`, `View Count`, `Like Count`,
+    `Comment Count`, `Duration`, `Description`, `Description Links`, `Hashtags`,
+    `Metrics Captured At`, plus formulas `Views per Day` and `Engagement Rate %`. All written to
+    `updateFields`, so **a re-sweep is the metrics-refresh mechanism** — there is no other one.
+    Metrics are overwritten in place; only `Metrics Captured At` keeps them honest. No history.
 - **Channels** `tblaTYkbXc072XEsT` — find-or-create by `Channel Handle`
+  - Harvest config: `Harvest?` (checkbox), `Source URL`, `Last harvested` (stamped only after a
+    sweep with zero errors, so a failure stays visibly stale)
+  - Stats: `Subscribers`, `Total Videos`, `Total Views`, `Channel Description`, `Stats Captured At`
 
 ### Write invariants — non-negotiable, inherited by the normalizer
 
@@ -109,7 +152,11 @@ correction.
    is what both it and `background.js` used to do. (`Video ID oTphk2SVHNc` was in exactly this state
    until 2026-07-29; the two records held identical transcripts but disjoint links — 25 Shots on one,
    the Channel link and provenance on the other — so they were merged, not parked.)
-3. **Never touch `Triage Status` on update.** Set `Queued` on create only.
+3. **Never touch `Triage Status` on update.** Set `Queued` on create only. The Channels analogue is
+   **`Track`**: `upsertChannel` now PATCHes stats onto existing rows, and it must never write
+   `Track`. Both are human-owned routing, and both fail silently — a clobbered `Track` drops the
+   channel out of the working view without erroring. The protection is structural, not a rule to
+   remember: `transform.js` builds the stats object and `Track` is simply never in it.
 4. **Verify the write by querying `Video ID`.** Never trust a status flag — a reported `error` can be
    a false negative after a successful save. Acting on one caused a duplicate record on 2026-07-26.
 5. **Truncate transcripts over 100k chars** via `lib/transcript-utils.js` (GH-64), keeping
@@ -123,6 +170,14 @@ correction.
    **cannot** catch this, because it performs no writes. Machine-written values follow a slug
    convention: `youtube-web-ui-dom` (extension), `apify-youtube-scraper` (normalizer).
    Note the Airtable API cannot add choices — that is a manual UI step.
+
+   **Corollary: no actor-supplied value may go into a singleSelect/multipleSelects.** We control
+   the provenance slugs, so those are safe as selects. We do not control what YouTube returns, so a
+   field like `Hashtags` — which looks exactly like a multi-select — must be plain text, or the
+   first unseen tag 422s the whole record. Selects are for our vocabulary, never theirs.
+
+8. **A new field must exist in Airtable before anything writes to it.** An unknown field name 422s
+   the entire record, and `--dry-run` cannot catch that either, for the same reason. Schema first.
 
 Rationale and the incidents behind each: `docs/archive/FINDINGS-youtube-automation.md` §4–5.
 
@@ -164,12 +219,22 @@ No build step. Vanilla JS. Load unpacked at `chrome://extensions/`.
 
 ## Open issues
 
-- **GH-65 (open)** — lossless full-transcript storage, which would remove the GH-64 truncation shim.
-  Apify's `saveSubsToKVS` may resolve this nearly free by giving a hosted file URL. **Verify retention
-  first** — unnamed Apify key-value stores expire (roughly 7 days on lower plans), so a stored pointer
-  could rot. Named store, or copy the file out.
+- **GH-65 (open, low priority)** — lossless full-transcript storage, which would remove the GH-64
+  truncation shim. Apify's `saveSubsToKVS` may resolve this nearly free by giving a hosted file URL.
+  **Verify retention first** — unnamed Apify key-value stores expire (roughly 7 days on lower plans),
+  so a stored pointer could rot. Named store, or copy the file out. Note observed transcripts run
+  11k–44k chars against a 100k limit, so nothing has actually truncated yet — this is a latent
+  problem, not a live one.
 - **GH-64 (fixed)** — truncation shim in place, but it now runs unattended with nobody reading the
   warning.
+- **No metrics history.** `View Count` and friends are overwritten on each sweep with only
+  `Metrics Captured At` to date them, so you can see a video's velocity *now* but not its trend. A
+  snapshot table is the upgrade path if "is this angle gaining?" becomes worth answering; it was
+  deliberately not built (2026-07-30 decision).
+- **Formula display precision is a UI-only setting.** `Views per Day` and `Engagement Rate %` are
+  formatted to 0 decimals because the API can't set it (`update_field` accepts only
+  `options.formula`). Display only — the stored values are exact. Fix in the Airtable UI if the grid
+  needs decimals.
 - **GH-69, GH-70 (to close)** — click-delivery investigations, superseded by the Apify pivot. Findings
   preserved in the archive doc.
 - Provenance guard (GH-68 fix item #2) never implemented. Only matters if the extension is revived,

--- a/docs/NORMALIZER-MANIFEST.md
+++ b/docs/NORMALIZER-MANIFEST.md
@@ -34,24 +34,72 @@ Note for future schema work: **the Airtable API cannot add singleSelect choices.
 `INVALID_REQUEST_UNKNOWN`. Adding `apify-youtube-scraper` to `Transcript Source` had to be done by
 hand in the UI, and it blocked every write until it existed.
 
+## 2026-07-30 — metrics, repurposing fields, and Airtable-driven batch sweeps
+
+Branch `feat/metrics-fields`. 64 unit tests green. The actor returns 45 keys per item and the
+normalizer consumed 9; everything metrics- and description-shaped was being paid for and discarded.
+That is now mapped, and the harvest config moved into Airtable as originally designed.
+
+**New Videos fields** (all in `updateFields`, so a re-sweep refreshes them — that *is* the metrics
+refresh mechanism): `Published At`←`date`, `View Count`←`viewCount`, `Like Count`←`likes`,
+`Comment Count`←`commentsCount`, `Duration`←parsed `duration`, `Description`←`text`,
+`Description Links`←`descriptionLinks[].url` (deduped, one per line), `Hashtags`←`hashtags`,
+`Metrics Captured At`. Plus two Airtable formulas: `Views per Day` (velocity — raw view count only
+rewards old videos) and `Engagement Rate %`.
+
+**New Channels fields**: `Subscribers`, `Total Videos`, `Total Views`, `Channel Description`,
+`Stats Captured At`, plus the harvest config `Harvest?` / `Source URL` / `Last harvested`.
+`upsertChannel` gained an update path so these reach the 88 existing rows, not just new ones.
+
+**`--from-airtable`** sweeps every `Harvest?`-ticked Channel. `--max-results` and
+`--oldest-post-date` remain mandatory: batch mode multiplies cost by the channel count, so it needs
+*more* bounding, not less.
+
+Verified live by querying Airtable, not by exit codes:
+
+| Check | Result |
+|---|---|
+| Batch, 5 channels × `--max-results 3` | 12 Videos created, 3 updated, 0 errors |
+| New fields on a swept record | `View Count` 11368, `Duration` 836s, `Published At` set, `Views per Day` 11368, `Engagement Rate %` 3.83, hashtags as plain text |
+| Channel stats on **existing** rows | all 5 got `Subscribers`/`Total Views`/`Stats Captured At`; `Track` unchanged on every one |
+| `Last harvested` | stamped on all 5 (clean sweeps only — a run with errors deliberately leaves it stale) |
+| **Queue ceiling in batch** | with `--queue-ceiling 10` against 16 Queued, it halted, named all 5 unswept channels, exit 1, and spent nothing on Apify |
+| Duplicates / forks | Videos 94→106, Channels stayed **88**; zero duplicate keys; zero UC-keyed rows |
+| **Invariant 3** | `eOebZr3BwSg` stayed `Declined` and `hFlBYtI7q7o` stayed `Done` through metric updates |
+
+Two things worth knowing before touching this again:
+
+- **Formula-field display precision is not settable over the API.** `create_field` returns
+  `result.options.precision: 0` and `update_field` accepts only `options.formula`. This is
+  *display-only* — verified: the API returns `11.5` and `4.35` for fields formatted to 0 decimals.
+  Set the decimals in the Airtable UI if the grid needs them; the stored values are already exact.
+- **No actor-supplied value may go into a singleSelect/multipleSelects.** `Hashtags` is the obvious
+  trap — it looks like a multi-select, but the values come from the actor, the API cannot add
+  choices, and an unseen value 422s the entire record. It is deliberately plain text.
+
 ## What exists now
 
 ```
 normalizer/
 ├── package.json              — scripts: test, harvest
-├── apify-harvest.js           — the CLI entrypoint
+├── apify-harvest.js           — the CLI entrypoint (single-channel and --from-airtable batch)
+├── apify-harvest.test.js
 └── lib/
     ├── apify-client.js        — runActorSync() against streamers/youtube-scraper
-    ├── airtable-client.js     — countQueued, upsertChannel, upsertVideo (find-or-create/upsert)
-    ├── transform.js           — Apify dataset item -> Airtable fields
+    ├── airtable-client.js     — countQueued, listHarvestChannels, patchChannel,
+    │                            upsertChannel, upsertVideo (find-or-create/upsert)
+    ├── airtable-client.test.js
+    ├── transform.js           — Apify dataset item -> Airtable fields (+ metrics, channel stats)
     ├── transform.test.js
     ├── srt-parser.js          — parses Apify's non-standard inline SRT into {text, start}
     ├── srt-parser.test.js
     └── __fixtures__/
-        └── qdRw7oHDXJw.srt.txt  — real captured sample, trimmed, used by both test files
+        ├── qdRw7oHDXJw.srt.txt  — real captured sample, trimmed, used by both test files
+        └── channel-item.json    — a real channel-mode dataset item; its KEY SET is the
+                                   actor output contract, and the early warning for drift
 ```
 
-Run `cd normalizer && npm test` — 14 tests, all passing as of last run. These are pure unit
+Run `cd normalizer && npm test` — 64 tests, all passing as of 2026-07-30. These are pure unit
 tests (fixture-based); they do not touch the network.
 
 `.gitignore` had a blanket `lib/` rule that was silently swallowing `normalizer/lib/` (the same
@@ -77,8 +125,9 @@ Confirmed via two real single-video probe runs (`https://www.youtube.com/watch?v
   run-then-poll-then-fetch-dataset needed for small bounded runs.
 - Field mapping used in `transform.js`:
   `id`→Video ID, `title`→Video Title, `url`→Video URL, `thumbnailUrl`→Thumbnail URL/(Image),
-  `channelName`→Channel Name, `channelUrl`→Channel URL, `date`→(publish date, not stored;
-  used only to verify `oldestPostDate` bounding).
+  `channelName`→Channel Name, `channelUrl`→Channel URL, `date`→**`Published At`** (as of
+  2026-07-30 this is stored, not just used to verify `oldestPostDate` bounding), plus the metrics
+  and channel-stats keys listed in the 2026-07-30 section above.
 
 - ⚠️ **CORRECTED 2026-07-29 — this doc previously had the channel key wrong.** It claimed
   `channelId`→Channel Handle (the `UC...` id) was "confirmed against real output" and "matches how
@@ -165,19 +214,20 @@ The original steps 1–3 are **done** — dry-run smoke test, channel-mode probe
 the idempotency/invariant-3 re-run all ran live on 2026-07-29. Findings are folded in above.
 What remains:
 
-1. **Set `Track` on the new `@WayneStLedger` Channel** (`rec4cdSg0ws368gtK`) — currently blank, so
-   its two videos are invisible in the AIHS working view. Needs a human call: `AIHS`,
-   `Tooling-watch`, or `Personal`. Neither the CLI nor a future session should guess it.
+1. ~~Set `Track` on `@WayneStLedger`~~ — **done**, it is `Tooling-watch` as of 2026-07-30.
 
 2. **Track-unset view** — a Channels grid view filtered to blank `Track`. Manual UI step (the
-   Airtable MCP has no create-view tool). **29 of 88 Channels have blank `Track`**, so this is
-   fixing a live hole, not just guarding future sweeps.
+   Airtable MCP has no create-view tool). Now **4 of 88 Channels** have blank `Track`
+   (`@Jasper_Tech`, `@BulbDigital`, `@3.7Million`, `@WizardsandWarriors`) — down from 29, but the
+   view is still worth having, because a blank-`Track` channel fails by vanishing silently.
 
 3. Decide how this runs unattended — cron on an always-on machine? A Claude scheduled task? Manual?
-   Nothing in `apify-harvest.js` assumes an invocation method. Note the real constraint is not
-   capture any more: it's the human review gate downstream (see the queue ceiling, and item 5).
+   Nothing in `apify-harvest.js` assumes an invocation method, and `--from-airtable` now makes an
+   unattended invocation a single command with no channel list baked into it. Note the real
+   constraint is not capture any more: it's the human review gate downstream (see the queue
+   ceiling, and item 5).
 
-4. Merge `feat/apify-normalizer` into `master`.
+4. ~~Merge `feat/apify-normalizer`~~ — **done** (`3a878d1`). `feat/metrics-fields` is the open one.
 
 5. Not this normalizer's job, but adjacent and worth remembering: the receiving-end refinery
    (`~/claude/Youtube Transcripts`) still has its own gate closed — "Still gated until treatment
@@ -193,7 +243,14 @@ What remains:
   partial progress isn't corrupt, just incomplete).
 - Shorts/streams (`maxResultsShorts`, `maxResultStreams`) — not wired up. Only `maxResults`
   (regular videos) is passed today.
-- Any per-channel config stored in Airtable (`Harvest?`, `Source URL`, `Last harvested` on
-  Channels) — the original design doc mentions these but they don't exist yet and
-  `apify-harvest.js` takes `--channel-url` on the command line instead. Worth revisiting once
-  you're running this against more than one channel at a time.
+- ~~Per-channel config stored in Airtable~~ — **shipped 2026-07-30.** `Harvest?`, `Source URL` and
+  `Last harvested` exist on Channels and drive `--from-airtable`. `--channel-url` remains for
+  one-off runs.
+- **Metrics history.** Metrics are overwritten in place with a `Metrics Captured At` stamp, so
+  trend data is not recoverable after the fact — you can see what a video's velocity is *now*, not
+  what it was last week. A snapshot table is the upgrade path if "is this angle gaining?" ever
+  becomes a question worth answering; it was deliberately not built.
+- **Backfilling the extension-captured videos.** Videos captured before the sweep window stay
+  metric-less. Note this partially self-heals: a re-swept channel updates any of its videos that
+  still fall inside `--oldest-post-date`, which is how `hFlBYtI7q7o` (a `Done` record from
+  2026-07-11) gained metrics without being re-created.

--- a/normalizer/apify-harvest.js
+++ b/normalizer/apify-harvest.js
@@ -8,31 +8,32 @@
 //
 //   - --max-results and --oldest-post-date are MANDATORY on every run,
 //     dry-run or not. No unbounded channel pulls. (Guardrail.)
-//   - Queue-depth ceiling: refuses to run while Triage Status=Queued count
-//     in Airtable is already at/above --queue-ceiling (default 30).
+//   - Queue-depth ceiling: stops before any channel while the Triage
+//     Status=Queued count in Airtable is at/above --queue-ceiling (default
+//     30). Re-checked per channel, not once per run — see main().
 //   - --dry-run performs all reads (Apify call + Airtable existence checks)
 //     but no writes, and prints exactly what it would have written.
 //   - Reuses chrome-extension/lib/transcript-utils.js for GH-64 truncation,
 //     and the write invariants from background.js (upsert by Video ID,
 //     never touch Triage Status on update, Channel found/created by
-//     Channel Handle = channelId).
+//     Channel Handle = '@' + channelUsername).
 //
-// KNOWN GAP (2026-07-29): "oldestPostDate" is confirmed to be a REAL actor
-// input key (documented as "only posts uploaded after or on this date"; it
-// also accepts a relative value like "7 days"). What is NOT yet confirmed is
-// that the actor actually HONORS it in channel-sweep mode — an accepted-but-
-// ignored field looks identical to a working one until --max-results is
-// raised, at which point a "bounded" sweep walks the whole channel history.
-// Prove it with --save-raw: check the captured publish dates against the
-// bound, then re-run with a recent date and confirm the item set changes.
-// Until that negative control passes, --max-results is the only real bound.
+// "oldestPostDate" is HONORED, not merely accepted — proven 2026-07-29 by
+// negative control: bounding the same call at a later date returned 1 item
+// instead of 2. It also accepts relative values like "7 days".
 
 const fs = require('node:fs');
 const path = require('node:path');
 
 const { runActorSync } = require('./lib/apify-client');
 const { buildVideoFields } = require('./lib/transform');
-const { countQueued, upsertChannel, upsertVideo } = require('./lib/airtable-client');
+const {
+  countQueued,
+  listHarvestChannels,
+  patchChannel,
+  upsertChannel,
+  upsertVideo,
+} = require('./lib/airtable-client');
 
 function loadDotEnv() {
   const envPath = path.join(__dirname, '..', '.env');
@@ -45,21 +46,25 @@ function loadDotEnv() {
 
 const USAGE = `Usage:
   node apify-harvest.js --channel-url <url> --max-results <n> --oldest-post-date <YYYY-MM-DD> [options]
+  node apify-harvest.js --from-airtable  --max-results <n> --oldest-post-date <YYYY-MM-DD> [options]
 
-Required (guardrail: no unbounded channel pulls):
-  --channel-url <url>          Channel to harvest, e.g. https://www.youtube.com/@Someone
-  --max-results <n>            Max regular videos to pull
+Channel selection (exactly one):
+  --channel-url <url>          One channel, e.g. https://www.youtube.com/@Someone
+  --from-airtable              Every Channel row with Harvest? ticked, using its Source URL
+
+Required in both modes (guardrail: no unbounded channel pulls):
+  --max-results <n>            Max regular videos to pull, PER CHANNEL
   --oldest-post-date <date>    Only videos on/after this date (ISO, or relative like "7 days")
 
 Options:
-  --queue-ceiling <n>          Refuse to run if Queued count >= n (default 30)
+  --queue-ceiling <n>          Stop before any channel whose Queued count >= n (default 30)
   --dry-run                    Do every read, print intended writes, write nothing
-  --save-raw <path>            Dump the raw Apify dataset to <path> for inspection
+  --save-raw <path>            Dump the raw Apify dataset to <path> (one file per channel in batch mode)
   --help                       Show this message
 `;
 
 function parseArgs(argv) {
-  const args = { dryRun: false, queueCeiling: 30, help: false };
+  const args = { dryRun: false, fromAirtable: false, queueCeiling: 30, help: false };
   for (let i = 0; i < argv.length; i++) {
     // Accept both "--flag value" and "--flag=value".
     const raw = argv[i];
@@ -83,6 +88,9 @@ function parseArgs(argv) {
         break;
       case '--save-raw':
         args.saveRaw = takeValue();
+        break;
+      case '--from-airtable':
+        args.fromAirtable = true;
         break;
       case '--dry-run':
         args.dryRun = true;
@@ -112,7 +120,13 @@ function elideTranscripts(fields) {
 
 function validateArgs(args) {
   const errors = [];
-  if (!args.channelUrl) errors.push('--channel-url is required');
+  // Exactly one channel source. Accepting both would silently ignore one of
+  // them, and the harvest config living in two places is the failure mode the
+  // Airtable-driven design exists to avoid.
+  if (!args.channelUrl && !args.fromAirtable) errors.push('one of --channel-url or --from-airtable is required');
+  if (args.channelUrl && args.fromAirtable) errors.push('--channel-url and --from-airtable are mutually exclusive');
+  // Per-channel bounds stay mandatory in batch mode: --from-airtable multiplies
+  // the cost by the number of ticked channels, so it needs MORE bounding, not less.
   if (!args.maxResults || args.maxResults <= 0) errors.push('--max-results is required and must be > 0 (guardrail: no unbounded pulls)');
   if (!args.oldestPostDate) errors.push('--oldest-post-date is required (guardrail: no unbounded pulls) — format YYYY-MM-DD');
   if (errors.length) {
@@ -120,33 +134,33 @@ function validateArgs(args) {
   }
 }
 
-async function main() {
-  loadDotEnv();
-  const args = parseArgs(process.argv.slice(2));
-  if (args.help) {
-    console.log(USAGE);
-    return;
-  }
-  validateArgs(args);
+function emptySummary() {
+  return { created: 0, updated: 0, wouldCreate: 0, wouldUpdate: 0, skipped: 0, channelsCreated: 0, errors: 0 };
+}
 
-  const apifyToken = process.env.APIFY_TOKEN;
-  const airtableKey = process.env.AIRTABLE_API_KEY;
-  const baseId = process.env.AIRTABLE_BASE_ID;
+function mergeSummary(total, part) {
+  for (const key of Object.keys(total)) total[key] += part[key];
+}
 
-  if (!apifyToken) throw new Error('APIFY_TOKEN not set (.env)');
-  if (!airtableKey || !baseId) throw new Error('AIRTABLE_API_KEY / AIRTABLE_BASE_ID not set (.env)');
+// In batch mode one --save-raw path would have each channel overwrite the last,
+// so give each its own file. Single-channel runs keep the exact path given.
+function rawPathFor(basePath, channel, index, isBatch) {
+  if (!isBatch) return basePath;
+  const slug = String(channel.channelName).replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 40);
+  const ext = path.extname(basePath);
+  return path.join(
+    path.dirname(basePath),
+    `${path.basename(basePath, ext)}.${String(index + 1).padStart(2, '0')}-${slug}${ext}`
+  );
+}
 
-  console.log(`[queue check] querying Triage Status=Queued count...`);
-  const queuedCount = await countQueued(airtableKey, baseId);
-  console.log(`[queue check] ${queuedCount} currently Queued (ceiling: ${args.queueCeiling})`);
-  if (queuedCount >= args.queueCeiling) {
-    console.error(`Refusing to harvest: Queued count (${queuedCount}) is at/above the ceiling (${args.queueCeiling}). The refinery's bottleneck is the human review gate, not capture — clear the queue before sweeping more in.`);
-    process.exitCode = 1;
-    return;
-  }
+// Harvest one channel. Returns its own summary so the caller can decide
+// whether the sweep was clean enough to stamp Last harvested.
+async function sweepChannel({ apifyToken, airtableKey, baseId, channel, args, capturedAt, rawPath }) {
+  const summary = emptySummary();
 
   const input = {
-    startUrls: [{ url: args.channelUrl }],
+    startUrls: [{ url: channel.sourceUrl }],
     maxResults: args.maxResults,
     oldestPostDate: args.oldestPostDate,
     downloadSubtitles: true,
@@ -162,12 +176,10 @@ async function main() {
 
   // Write the raw capture before any processing, so a later failure still
   // leaves the observed output on disk to inspect and turn into a fixture.
-  if (args.saveRaw) {
-    fs.writeFileSync(args.saveRaw, JSON.stringify(items, null, 2));
-    console.log(`[apify] raw dataset written to ${args.saveRaw}`);
+  if (rawPath) {
+    fs.writeFileSync(rawPath, JSON.stringify(items, null, 2));
+    console.log(`[apify] raw dataset written to ${rawPath}`);
   }
-
-  const summary = { created: 0, updated: 0, wouldCreate: 0, wouldUpdate: 0, skipped: 0, channelsCreated: 0, errors: 0 };
 
   // A channel sweep is all one channel, so resolve it once. Without this every
   // video re-queries Channels — wasted requests against Airtable's 5 req/s cap
@@ -176,7 +188,7 @@ async function main() {
   const channelCache = new Map();
 
   for (const item of items) {
-    const built = buildVideoFields(item);
+    const built = buildVideoFields(item, { capturedAt });
     if (built.skipped) {
       console.warn(`[skip] ${item?.id || '(no id)'}: ${built.skipped}`);
       summary.skipped++;
@@ -200,7 +212,8 @@ async function main() {
           summary.channelsCreated++;
           console.warn(`[channel] created "${built.channel.channelName}" (${channelKey}) with NO Track set — it will silently vanish from the working view (Track = AIHS OR Tooling-watch) until someone sets Track by hand.`);
         } else if (channelResult.matchedOn) {
-          console.log(`[channel] matched existing "${built.channel.channelName}" on ${channelResult.matchedOn}`);
+          const stats = channelResult.statsUpdated ? ', stats refreshed' : '';
+          console.log(`[channel] matched existing "${built.channel.channelName}" on ${channelResult.matchedOn}${stats}`);
         } else if (channelResult.skipped) {
           console.warn(`[channel] ${built.videoId}: ${channelResult.skipped} — video will have no Channel link`);
         }
@@ -235,10 +248,116 @@ async function main() {
     }
   }
 
-  console.log('\n[summary]', JSON.stringify(summary, null, 2));
+  return summary;
+}
+
+// Resolve the channels to sweep: either the single --channel-url, or every
+// Harvest?-ticked row in Airtable. A ticked row with no Source URL is a
+// configuration mistake, so warn rather than guessing a URL from the handle.
+async function resolveChannels(args, airtableKey, baseId) {
+  if (!args.fromAirtable) {
+    return [{ recordId: null, channelName: args.channelUrl, sourceUrl: args.channelUrl }];
+  }
+
+  const rows = await listHarvestChannels(airtableKey, baseId);
+  console.log(`[config] ${rows.length} channel(s) with Harvest? ticked`);
+
+  const usable = [];
+  for (const row of rows) {
+    if (!row.sourceUrl) {
+      console.warn(`[config] skipping "${row.channelName}" — Harvest? is ticked but Source URL is blank`);
+      continue;
+    }
+    usable.push(row);
+  }
+  return usable;
+}
+
+async function main() {
+  loadDotEnv();
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+  validateArgs(args);
+
+  const apifyToken = process.env.APIFY_TOKEN;
+  const airtableKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+
+  if (!apifyToken) throw new Error('APIFY_TOKEN not set (.env)');
+  if (!airtableKey || !baseId) throw new Error('AIRTABLE_API_KEY / AIRTABLE_BASE_ID not set (.env)');
+
+  // One timestamp for the whole run, so every record swept together carries
+  // the same Metrics Captured At and the snapshot is comparable across rows.
+  const capturedAt = new Date().toISOString();
+
+  const channels = await resolveChannels(args, airtableKey, baseId);
+  if (channels.length === 0) {
+    console.error('Nothing to harvest: no channel had both Harvest? ticked and a Source URL set.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const isBatch = channels.length > 1;
+  const total = emptySummary();
+  let stopped = null;
+
+  for (const [index, channel] of channels.entries()) {
+    // Re-check the ceiling before EVERY channel, not once per run. Checking
+    // once and then sweeping ten channels through that single verdict is how a
+    // guardrail stops guarding at exactly the moment volume arrives — the
+    // refinery's bottleneck is the human review gate, and this is what keeps
+    // capture from outrunning it.
+    const queuedCount = await countQueued(airtableKey, baseId);
+    if (queuedCount >= args.queueCeiling) {
+      stopped = { queuedCount, remaining: channels.slice(index) };
+      break;
+    }
+
+    console.log(`\n=== [${index + 1}/${channels.length}] ${channel.channelName} — ${queuedCount} Queued (ceiling: ${args.queueCeiling}) ===`);
+
+    // One bad channel must not abandon the rest of the batch.
+    try {
+      const summary = await sweepChannel({
+        apifyToken,
+        airtableKey,
+        baseId,
+        channel,
+        args,
+        capturedAt,
+        rawPath: args.saveRaw ? rawPathFor(args.saveRaw, channel, index, isBatch) : null,
+      });
+      mergeSummary(total, summary);
+      console.log(`[channel summary] ${channel.channelName}:`, JSON.stringify(summary));
+
+      // Stamp Last harvested only on a clean sweep. A run with errors
+      // deliberately leaves it stale so the gap stays visible in the base.
+      if (channel.recordId && summary.errors === 0 && !args.dryRun) {
+        await patchChannel(airtableKey, baseId, channel.recordId, { 'Last harvested': capturedAt });
+        console.log(`[config] stamped Last harvested on "${channel.channelName}"`);
+      } else if (channel.recordId && summary.errors > 0) {
+        console.warn(`[config] NOT stamping Last harvested on "${channel.channelName}" — ${summary.errors} error(s), so it stays visibly stale.`);
+      }
+    } catch (error) {
+      total.errors++;
+      console.error(`[error] channel "${channel.channelName}": ${error.message}`);
+    }
+  }
+
+  console.log('\n[summary]', JSON.stringify(total, null, 2));
+
+  if (stopped) {
+    console.error(
+      `\nStopped before ${stopped.remaining.length} remaining channel(s): Queued count (${stopped.queuedCount}) reached the ceiling (${args.queueCeiling}). The refinery's bottleneck is the human review gate, not capture — clear the queue, then re-run.\n  Not swept: ${stopped.remaining.map((c) => c.channelName).join(', ')}`
+    );
+    process.exitCode = 1;
+  }
+
   if (args.dryRun) console.log('\nDry run — nothing was written to Airtable.');
-  if (summary.errors > 0) {
-    console.error(`\n${summary.errors} item(s) failed — see [error] lines above.`);
+  if (total.errors > 0) {
+    console.error(`\n${total.errors} item(s) failed — see [error] lines above.`);
     process.exitCode = 1;
   }
 }

--- a/normalizer/apify-harvest.test.js
+++ b/normalizer/apify-harvest.test.js
@@ -46,10 +46,32 @@ test('--help short-circuits without needing the mandatory args', () => {
 
 // The mandatory bounds are the guardrail against an unbounded channel pull,
 // so they must fail closed — dry run or not.
-test('validateArgs requires all three bounds', () => {
-  assert.throws(() => validateArgs(parseArgs([])), /--channel-url is required/);
+test('validateArgs requires a channel source and all bounds', () => {
+  assert.throws(() => validateArgs(parseArgs([])), /one of --channel-url or --from-airtable is required/);
   assert.throws(() => validateArgs(parseArgs([])), /--max-results is required/);
   assert.throws(() => validateArgs(parseArgs([])), /--oldest-post-date is required/);
+});
+
+test('validateArgs rejects both channel sources at once', () => {
+  // Two sources of truth for "which channels" is precisely what moving the
+  // config into Airtable exists to avoid, so refuse rather than pick one.
+  const args = parseArgs([...REQUIRED, '--from-airtable']);
+  assert.throws(() => validateArgs(args), /mutually exclusive/);
+});
+
+// --from-airtable multiplies the cost by the number of ticked channels, so it
+// needs the per-channel bounds MORE than a single-channel run does.
+test('--from-airtable still requires the per-channel bounds', () => {
+  assert.throws(() => validateArgs(parseArgs(['--from-airtable'])), /--max-results is required/);
+  assert.throws(() => validateArgs(parseArgs(['--from-airtable'])), /--oldest-post-date is required/);
+  assert.doesNotThrow(() =>
+    validateArgs(parseArgs(['--from-airtable', '--max-results', '5', '--oldest-post-date', '30 days']))
+  );
+});
+
+test('parseArgs defaults --from-airtable to false', () => {
+  assert.equal(parseArgs(REQUIRED).fromAirtable, false);
+  assert.equal(parseArgs(['--from-airtable']).fromAirtable, true);
 });
 
 test('validateArgs rejects a zero, negative, or non-numeric --max-results', () => {

--- a/normalizer/lib/airtable-client.js
+++ b/normalizer/lib/airtable-client.js
@@ -81,27 +81,75 @@ async function findChannelByHandle(apiKey, baseId, channelHandle) {
   return exactlyOneOrNull(result.records, 'Channel Handle', channelHandle);
 }
 
+// PATCH arbitrary fields onto one Channel row. Callers are responsible for
+// what they put in `fields` — see the invariant note on upsertChannel about
+// what must never appear there.
+async function patchChannel(apiKey, baseId, recordId, fields) {
+  return airtableRequest(apiKey, `${baseId}/Channels/${recordId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ fields }),
+  });
+}
+
+// The harvest queue: every Channel with Harvest? ticked. This is why the
+// config lives in Airtable rather than a repo JSON file — adding a channel to
+// the sweep is a checkbox, not a commit.
+async function listHarvestChannels(apiKey, baseId) {
+  const formula = encodeURIComponent('{Harvest?}=1');
+  const result = await airtableRequest(
+    apiKey,
+    `${baseId}/Channels?filterByFormula=${formula}&pageSize=100`
+  );
+  return (result.records || []).map((record) => ({
+    recordId: record.id,
+    channelName: record.fields['Channel Name'] || '(unnamed)',
+    sourceUrl: record.fields['Source URL'] || null,
+    lastHarvested: record.fields['Last harvested'] || null,
+  }));
+}
+
 // Find-or-create a Channel by Channel Handle.
 //
 // Looks up `handleKey` (@handle — what all existing rows use, see
 // transform.js) first, then `fallbackKey` (the UC... id) so a row created by
 // some other path is still found rather than forked. Creates with handleKey
-// when we have one. Returns { recordId, created, matchedOn }.
+// when we have one. Returns { recordId, created, matchedOn, statsUpdated }.
 //
 // `created: true` means this Channel has no Track set yet — per CLAUDE.md a
 // blank-Track Channel silently vanishes from the AIHS working view
 // (Track = AIHS OR Tooling-watch). Callers should surface `created` loudly.
-async function upsertChannel(apiKey, baseId, { handleKey, fallbackKey, channelName, channelUrl }, { dryRun } = {}) {
+//
+// INVARIANT: on an existing row this writes `stats` and nothing else. `Track`
+// is human-owned routing — the exact same category as Triage Status on Videos
+// (invariant 3), and clobbering it would silently drop a channel out of the
+// refinery's working view. transform.js builds `stats` and never puts Track in
+// it, so the protection is structural rather than a rule to remember here.
+async function upsertChannel(
+  apiKey,
+  baseId,
+  { handleKey, fallbackKey, channelName, channelUrl, stats },
+  { dryRun } = {}
+) {
   const writeKey = handleKey || fallbackKey;
   if (!writeKey || !channelName) return { recordId: null, created: false, skipped: 'missing channel info' };
+
+  const statsFields = stats && Object.keys(stats).length > 0 ? stats : null;
 
   for (const [label, key] of [['handle', handleKey], ['channelId', fallbackKey]]) {
     if (!key) continue;
     const existing = await findChannelByHandle(apiKey, baseId, key);
-    if (existing) return { recordId: existing.id, created: false, matchedOn: label };
+    if (!existing) continue;
+
+    if (statsFields && !dryRun) await patchChannel(apiKey, baseId, existing.id, statsFields);
+    return {
+      recordId: existing.id,
+      created: false,
+      matchedOn: label,
+      statsUpdated: Boolean(statsFields) && !dryRun,
+    };
   }
 
-  if (dryRun) return { recordId: '<dry-run: would create>', created: true };
+  if (dryRun) return { recordId: '<dry-run: would create>', created: true, statsUpdated: false };
 
   const created = await airtableRequest(apiKey, `${baseId}/Channels`, {
     method: 'POST',
@@ -111,11 +159,12 @@ async function upsertChannel(apiKey, baseId, { handleKey, fallbackKey, channelNa
         Platform: 'YouTube',
         'Channel Handle': writeKey,
         'Channel URL': channelUrl || `https://www.youtube.com/channel/${fallbackKey || ''}`,
+        ...(statsFields || {}),
       },
     }),
   });
 
-  return { recordId: created.id, created: true };
+  return { recordId: created.id, created: true, statsUpdated: Boolean(statsFields) };
 }
 
 // Upsert a Videos record by Video ID. `fields` should already be built
@@ -152,6 +201,8 @@ module.exports = {
   countQueued,
   findVideoByVideoId,
   findChannelByHandle,
+  listHarvestChannels,
+  patchChannel,
   upsertChannel,
   upsertVideo,
 };

--- a/normalizer/lib/airtable-client.test.js
+++ b/normalizer/lib/airtable-client.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   findVideoByVideoId,
   findChannelByHandle,
+  listHarvestChannels,
   upsertChannel,
   upsertVideo,
 } = require('./airtable-client');
@@ -74,7 +75,7 @@ test('upsertChannel matches on @handle and never queries the UC id', async (t) =
     channelName: 'Wayne',
   });
 
-  assert.deepEqual(result, { recordId: 'recChan', created: false, matchedOn: 'handle' });
+  assert.deepEqual(result, { recordId: 'recChan', created: false, matchedOn: 'handle', statsUpdated: false });
   assert.equal(f.calls.length, 1, 'UC fallback should not be queried after a handle hit');
 });
 
@@ -108,7 +109,7 @@ test('upsertChannel creates with the @handle, not the UC id', async (t) => {
     channelUrl: 'https://www.youtube.com/@Wayne',
   });
 
-  assert.deepEqual(result, { recordId: 'recNew', created: true });
+  assert.deepEqual(result, { recordId: 'recNew', created: true, statsUpdated: false });
   const post = f.calls.find((c) => c.method === 'POST');
   assert.equal(post.body.fields['Channel Handle'], '@Wayne');
   assert.equal(post.body.fields.Platform, 'YouTube');
@@ -120,6 +121,91 @@ test('upsertChannel skips when it has no usable key', async (t) => {
   const result = await upsertChannel(KEY, BASE, { handleKey: null, fallbackKey: null, channelName: 'X' });
   assert.equal(result.skipped, 'missing channel info');
   assert.equal(f.calls.length, 0, 'should not hit the API with no key');
+});
+
+// --- channel stats: refresh on match, never touch Track ---------------------
+
+test('upsertChannel PATCHes stats onto an existing row and leaves Track alone', async (t) => {
+  const f = installFetch((call) =>
+    call.method === 'PATCH' ? { id: 'recChan' } : { records: [{ id: 'recChan' }] }
+  );
+  t.after(f.restore);
+
+  const result = await upsertChannel(KEY, BASE, {
+    handleKey: '@Wayne',
+    fallbackKey: 'UCxxx',
+    channelName: 'Wayne',
+    stats: { Subscribers: 174, 'Total Views': 88652, 'Stats Captured At': '2026-07-30T00:00:00.000Z' },
+  });
+
+  assert.equal(result.statsUpdated, true);
+  const patch = f.calls.find((c) => c.method === 'PATCH');
+  assert.equal(patch.body.fields.Subscribers, 174);
+  // Track is human-owned routing — the Channels analogue of invariant 3. A
+  // blank/overwritten Track silently drops the channel out of the AIHS view.
+  assert.equal('Track' in patch.body.fields, false, 'Track must never be written');
+  assert.equal('Channel Handle' in patch.body.fields, false, 'the upsert key must never be rewritten');
+});
+
+test('upsertChannel skips the stats PATCH entirely when there are no stats', async (t) => {
+  const f = installFetch(() => ({ records: [{ id: 'recChan' }] }));
+  t.after(f.restore);
+
+  const result = await upsertChannel(KEY, BASE, { handleKey: '@Wayne', channelName: 'Wayne', stats: {} });
+
+  assert.equal(result.statsUpdated, false);
+  assert.equal(f.calls.every((c) => c.method === 'GET'), true, 'an empty stats object must not trigger a write');
+});
+
+test('upsertChannel dry run never PATCHes stats', async (t) => {
+  const f = installFetch(() => ({ records: [{ id: 'recChan' }] }));
+  t.after(f.restore);
+
+  const result = await upsertChannel(
+    KEY,
+    BASE,
+    { handleKey: '@Wayne', channelName: 'Wayne', stats: { Subscribers: 174 } },
+    { dryRun: true }
+  );
+
+  assert.equal(result.statsUpdated, false);
+  assert.equal(f.calls.every((c) => c.method === 'GET'), true, 'no writes in dry run');
+});
+
+test('a new channel is created with its stats already populated', async (t) => {
+  const f = installFetch((call) => (call.method === 'POST' ? { id: 'recNew' } : { records: [] }));
+  t.after(f.restore);
+
+  await upsertChannel(KEY, BASE, {
+    handleKey: '@Wayne',
+    channelName: 'Wayne',
+    stats: { Subscribers: 174 },
+  });
+
+  const post = f.calls.find((c) => c.method === 'POST');
+  assert.equal(post.body.fields.Subscribers, 174);
+  assert.equal(post.body.fields['Channel Handle'], '@Wayne');
+});
+
+// --- the harvest queue lives in Airtable, not in a repo file ----------------
+
+test('listHarvestChannels returns Harvest?-ticked rows with their Source URL', async (t) => {
+  const f = installFetch(() => ({
+    records: [
+      { id: 'recA', fields: { 'Channel Name': 'A', 'Source URL': 'https://youtube.com/@a' } },
+      { id: 'recB', fields: { 'Channel Name': 'B' } },
+    ],
+  }));
+  t.after(f.restore);
+
+  const rows = await listHarvestChannels(KEY, BASE);
+
+  assert.match(f.calls[0].url, /\{Harvest\?\}=1/);
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0].sourceUrl, 'https://youtube.com/@a');
+  // A ticked row with no Source URL is surfaced, not silently dropped here —
+  // the CLI warns about it so the misconfiguration is visible.
+  assert.equal(rows[1].sourceUrl, null);
 });
 
 // --- invariant 3: never touch Triage Status on update ----------------------

--- a/normalizer/lib/transform.js
+++ b/normalizer/lib/transform.js
@@ -34,6 +34,48 @@ function toHandleKey(item) {
   return null;
 }
 
+// The actor reports runtime as a "HH:MM:SS" (or "MM:SS") string; Airtable's
+// duration field wants seconds. Returns null on anything unparseable rather
+// than throwing — buildVideoFields is total by contract, and a weird duration
+// is not worth losing a whole video over.
+function parseDuration(value) {
+  if (typeof value !== 'string') return null;
+  const parts = value.trim().split(':');
+  if (parts.length < 2 || parts.length > 3) return null;
+
+  let seconds = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    seconds = seconds * 60 + Number(part);
+  }
+  return seconds;
+}
+
+// The publish date is the field that makes every view count interpretable, so
+// only accept it in the ISO shape the actor was observed to emit — a surprise
+// format is better left blank than silently stored as an unparseable string.
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/;
+
+// Assign only when the value is genuinely a finite number.
+//
+// This is deliberately a typeof check and not `if (value)`: `likes: 0` is a
+// real value in the observed fixture, and a truthiness guard would drop every
+// zero-like and zero-comment video — precisely the videos where the zero is
+// the informative part. Same reasoning for a missing metric: absent must stay
+// absent rather than becoming a fabricated 0.
+function assignNumber(fields, name, value) {
+  if (typeof value === 'number' && Number.isFinite(value)) fields[name] = value;
+}
+
+// Long text goes through the same GH-64 shim the transcripts use (invariant 5)
+// rather than being written raw — a 100k-char description would 422 the record.
+function assignLongText(fields, name, value, warnings, label) {
+  if (typeof value !== 'string' || value === '') return;
+  const fitted = TranscriptUtils.truncateForAirtable(value);
+  fields[name] = fitted.value;
+  if (fitted.truncated) warnings.push(`${label} truncated to 100k chars (GH-64)`);
+}
+
 // Apify can return several subtitle tracks. Taking [0] blindly stores a
 // non-English transcript under whatever language happened to come first, which
 // fails silently — prefer an en* track and fall back only if there isn't one.
@@ -45,12 +87,36 @@ function pickSubtitle(subtitles) {
   return english || subtitles[0];
 }
 
+// Channel-level stats, keyed by Airtable field name. Returned as its own
+// object so airtable-client can PATCH it onto an existing Channel row without
+// having to know which fields are stats and which are human-owned — `Track`
+// is never in here, so it is structurally impossible to clobber.
+function buildChannelStats(item, capturedAt) {
+  const stats = {};
+  assignNumber(stats, 'Subscribers', item.numberOfSubscribers);
+  assignNumber(stats, 'Total Videos', item.channelTotalVideos);
+  assignNumber(stats, 'Total Views', item.channelTotalViews);
+
+  if (typeof item.channelDescription === 'string' && item.channelDescription !== '') {
+    stats['Channel Description'] = TranscriptUtils.truncateForAirtable(item.channelDescription).value;
+  }
+
+  // Only stamp when something was actually captured — an empty stats object
+  // means "nothing to write", and a lone timestamp would claim otherwise.
+  if (capturedAt && Object.keys(stats).length > 0) stats['Stats Captured At'] = capturedAt;
+
+  return stats;
+}
+
 // Build { createOnlyFields, updateFields, channel, warnings } from one Apify
 // dataset item. Never throws — items missing subtitles still produce a
 // Video row (just without transcript fields), since Triage can't happen
 // without the video existing at all, and a missing transcript is visible
 // and fixable later rather than silently dropping the video.
-function buildVideoFields(item) {
+//
+// `capturedAt` is an ISO string computed once per run by the CLI, so every
+// record in one sweep shares a single timestamp.
+function buildVideoFields(item, { capturedAt } = {}) {
   const warnings = [];
 
   if (!item || !item.id) {
@@ -116,6 +182,51 @@ function buildVideoFields(item) {
     }
   }
 
+  // --- metrics and repurposing material --------------------------------------
+  //
+  // These live in updateFields, not createOnlyFields, and that is the whole
+  // refresh mechanism: they are machine-owned and time-varying, so re-sweeping
+  // a channel updates them in place for free. Nothing here is ever hand-edited,
+  // so unlike Triage Status (invariant 3) there is no human value to clobber.
+  //
+  // Metrics are a snapshot with no history — `Metrics Captured At` is what
+  // keeps a stored view count honest once it's a week old.
+  assignNumber(updateFields, 'View Count', item.viewCount);
+  assignNumber(updateFields, 'Like Count', item.likes);
+  assignNumber(updateFields, 'Comment Count', item.commentsCount);
+  assignNumber(updateFields, 'Duration', parseDuration(item.duration));
+
+  if (typeof item.date === 'string' && ISO_DATE.test(item.date)) {
+    updateFields['Published At'] = item.date;
+  }
+
+  // `text` is the video description: hooks, CTAs, chapter lists, offer framing.
+  assignLongText(updateFields, 'Description', item.text, warnings, 'description');
+
+  // Creators repeat the same link several times in a description, so dedupe
+  // while preserving order — the useful signal is which offers exist, not how
+  // many times each was mentioned.
+  if (Array.isArray(item.descriptionLinks)) {
+    const urls = [
+      ...new Set(
+        item.descriptionLinks
+          .map((link) => link?.url)
+          .filter((url) => typeof url === 'string' && url !== '')
+      ),
+    ];
+    assignLongText(updateFields, 'Description Links', urls.join('\n'), warnings, 'description links');
+  }
+
+  // Plain text, never a multi-select: these values come from the actor rather
+  // than from us, and a value that isn't an existing choice 422s the entire
+  // record (invariant 7). See the field description in Airtable.
+  if (Array.isArray(item.hashtags)) {
+    const tags = item.hashtags.filter((tag) => typeof tag === 'string' && tag !== '');
+    if (tags.length > 0) updateFields.Hashtags = tags.join(' ');
+  }
+
+  if (capturedAt) updateFields['Metrics Captured At'] = capturedAt;
+
   const handleKey = toHandleKey(item);
   if (!handleKey && item.channelId) {
     warnings.push(
@@ -132,9 +243,10 @@ function buildVideoFields(item) {
       fallbackKey: item.channelId || null,
       channelName: item.channelName,
       channelUrl: item.channelUrl,
+      stats: buildChannelStats(item, capturedAt),
     },
     warnings,
   };
 }
 
-module.exports = { buildVideoFields };
+module.exports = { buildVideoFields, parseDuration, buildChannelStats };

--- a/normalizer/lib/transform.test.js
+++ b/normalizer/lib/transform.test.js
@@ -2,7 +2,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
-const { buildVideoFields } = require('./transform');
+const { buildVideoFields, parseDuration, buildChannelStats } = require('./transform');
 
 const SRT_FIXTURE = fs.readFileSync(
   path.join(__dirname, '__fixtures__', 'qdRw7oHDXJw.srt.txt'),
@@ -175,4 +175,119 @@ test('the actor still reports the publish date as `date` in ISO form', () => {
   // --oldest-post-date bounding is only verifiable against this field, and the
   // 2026-07-29 negative control proved the actor honors the bound.
   assert.match(CHANNEL_ITEM.date, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+// --- metrics and repurposing material ---------------------------------------
+
+test('parseDuration converts the actor\'s clock string to seconds', () => {
+  assert.equal(parseDuration('00:10:44'), 644);
+  assert.equal(parseDuration('10:44'), 644);
+  assert.equal(parseDuration('1:00:00'), 3600);
+  assert.equal(parseDuration('00:00:00'), 0);
+});
+
+test('parseDuration returns null rather than throwing on junk', () => {
+  // buildVideoFields is total by contract — a weird duration must not cost us
+  // the whole video.
+  for (const bad of [undefined, null, '', 'LIVE', '12', '1:2:3:4', 'a:b', 3600]) {
+    assert.equal(parseDuration(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test('the real item maps metrics, description, and links into updateFields', () => {
+  const result = buildVideoFields(CHANNEL_ITEM, { capturedAt: '2026-07-30T12:00:00.000Z' });
+  const f = result.updateFields;
+
+  assert.equal(f['View Count'], 24);
+  assert.equal(f['Comment Count'], 1);
+  assert.equal(f.Duration, 644);
+  assert.equal(f['Published At'], '2026-07-29T16:14:33.000Z');
+  assert.equal(f['Metrics Captured At'], '2026-07-30T12:00:00.000Z');
+  assert.ok(f.Description.includes('Claude Code token usage'));
+  assert.deepEqual(f['Description Links'].split('\n'), [
+    'https://www.skool.com/marketing-hub-8910',
+    'https://leads.stledgermarketing.com/weekly-live-calls/',
+  ]);
+  assert.deepEqual(result.warnings, []);
+});
+
+test('a zero metric is written as 0, not dropped', () => {
+  // `likes: 0` is real observed output. A truthiness guard would drop exactly
+  // the videos where the zero is the informative part.
+  const result = buildVideoFields(CHANNEL_ITEM);
+  assert.equal(CHANNEL_ITEM.likes, 0);
+  assert.equal(result.updateFields['Like Count'], 0);
+  assert.equal('Like Count' in result.updateFields, true);
+});
+
+test('a missing metric is omitted rather than fabricated as 0', () => {
+  const result = buildVideoFields(baseItem({ viewCount: null, likes: undefined, commentsCount: 'NaN' }));
+  assert.equal('View Count' in result.updateFields, false);
+  assert.equal('Like Count' in result.updateFields, false);
+  assert.equal('Comment Count' in result.updateFields, false);
+});
+
+test('an empty hashtags array writes no Hashtags field', () => {
+  assert.deepEqual(CHANNEL_ITEM.hashtags, []);
+  const result = buildVideoFields(CHANNEL_ITEM);
+  assert.equal('Hashtags' in result.updateFields, false);
+});
+
+test('hashtags are space-joined plain text, never a select value', () => {
+  const result = buildVideoFields(baseItem({ hashtags: ['#ai', '#copilot'] }));
+  assert.equal(result.updateFields.Hashtags, '#ai #copilot');
+  assert.equal(typeof result.updateFields.Hashtags, 'string');
+});
+
+test('duplicate description links are collapsed, order preserved', () => {
+  const result = buildVideoFields(
+    baseItem({
+      descriptionLinks: [
+        { url: 'https://a.example' },
+        { url: 'https://b.example' },
+        { url: 'https://a.example' },
+        { text: 'no url here' },
+      ],
+    })
+  );
+  assert.deepEqual(result.updateFields['Description Links'].split('\n'), [
+    'https://a.example',
+    'https://b.example',
+  ]);
+});
+
+test('a non-ISO publish date is left blank rather than stored unparseable', () => {
+  const result = buildVideoFields(baseItem({ date: 'last Tuesday' }));
+  assert.equal('Published At' in result.updateFields, false);
+});
+
+test('no capturedAt means no Metrics Captured At claim', () => {
+  const result = buildVideoFields(baseItem());
+  assert.equal('Metrics Captured At' in result.updateFields, false);
+});
+
+// --- channel stats -----------------------------------------------------------
+
+test('buildChannelStats maps the channel-level numbers and never emits Track', () => {
+  const stats = buildChannelStats(CHANNEL_ITEM, '2026-07-30T12:00:00.000Z');
+
+  assert.equal(stats.Subscribers, 174);
+  assert.equal(stats['Total Videos'], 393);
+  assert.equal(stats['Total Views'], 88652);
+  assert.ok(stats['Channel Description'].startsWith("Hi, I'm Wayne"));
+  assert.equal(stats['Stats Captured At'], '2026-07-30T12:00:00.000Z');
+  // Structural protection: airtable-client PATCHes this object verbatim onto
+  // an existing Channel row, so Track being absent here is what makes it safe.
+  assert.equal('Track' in stats, false);
+});
+
+test('buildChannelStats returns an empty object when the actor gives no stats', () => {
+  // An empty object is the signal for "no write at all" — a lone timestamp
+  // would claim a refresh that never happened.
+  assert.deepEqual(buildChannelStats({}, '2026-07-30T12:00:00.000Z'), {});
+});
+
+test('the channel descriptor carries stats through to the client', () => {
+  const result = buildVideoFields(CHANNEL_ITEM, { capturedAt: '2026-07-30T12:00:00.000Z' });
+  assert.equal(result.channel.stats.Subscribers, 174);
 });


### PR DESCRIPTION
## Why

The Apify actor returns **45 keys per dataset item**; the normalizer consumed **9**. Everything
metrics-shaped (`viewCount`, `likes`, `commentsCount`, `duration`, channel stats) and everything
content-shaped (`text`, `descriptionLinks`, `hashtags`) was already in the payload we pay for, and
was being discarded. `date` — the publish date — was fetched, asserted on in a test, and never
stored, which is what made a raw view count uninterpretable: you couldn't tell a 24-view video
published yesterday from one published last year.

Separately, "run more channels" meant re-invoking the CLI per channel with the URL living in shell
history. The harvest config moves into Airtable, as `CLAUDE.md` had already committed to by design.

## What changed

**Airtable schema (19 new fields, created before any code writes to them)**

- Videos: `Published At`, `View Count`, `Like Count`, `Comment Count`, `Duration`, `Description`,
  `Description Links`, `Hashtags`, `Metrics Captured At`, plus formulas `Views per Day` and
  `Engagement Rate %`.
- Channels: `Subscribers`, `Total Videos`, `Total Views`, `Channel Description`,
  `Stats Captured At`, plus harvest config `Harvest?` / `Source URL` / `Last harvested`.

**Code**

- `transform.js` — maps metrics/content into `updateFields` (not `createOnlyFields`), so a re-sweep
  refreshes them in place. That *is* the metrics-refresh mechanism; there is no other one.
- `airtable-client.js` — `upsertChannel` gained an update path, so stats reach the 88 existing
  Channel rows rather than only newly created ones. Adds `listHarvestChannels` and `patchChannel`.
- `apify-harvest.js` — `--from-airtable` sweeps every `Harvest?`-ticked channel. `--max-results`
  and `--oldest-post-date` stay mandatory in both modes.

**Tests: 43 → 64.**

## Reviewer notes

Three decisions worth a second opinion:

1. **The queue ceiling is re-checked before *each* channel**, not once per run. A single up-front
   check would let one verdict wave ten channels through — a guardrail that stops guarding exactly
   when volume arrives. This is the main correctness point of the batch change.
2. **`Hashtags` is plain text, not a multi-select**, despite looking exactly like one. Values come
   from the actor, not from us; the API cannot add select choices, and an unseen value 422s the
   *entire* record. Generalized in `CLAUDE.md` as a new invariant: no actor-supplied value may go
   into a select. A new invariant 8 also records that a field must exist before anything writes to
   it — neither failure mode is catchable by `--dry-run`, which performs no writes.
3. **Numbers are `typeof`-guarded, not truthiness-guarded.** `likes: 0` is real observed output, so
   `if (value)` would silently drop every zero-like and zero-comment video — precisely the ones
   where the zero is the informative part. A missing metric stays absent rather than becoming a
   fabricated `0`.

`upsertChannel`'s new update path writes only the stats object, and `Track` is never in that object
— the Channels analogue of the existing "never touch `Triage Status`" rule. Both are human-owned
routing that fails *silently* when clobbered. The protection is structural rather than a rule to
remember, and there's a test asserting `Track` never appears in the PATCH body.

## Verified live (by querying Airtable, not by exit codes — invariant 4)

| Check | Result |
|---|---|
| Batch, 5 channels x `--max-results 3` | 12 Videos created, 3 updated, 0 errors |
| New fields on a swept record | `View Count` 11368, `Duration` 836s, `Published At` set, `Views per Day` 11368, `Engagement Rate %` 3.83 |
| Channel stats on **existing** rows | all 5 got `Subscribers`/`Total Views`/`Stats Captured At`; `Track` unchanged on every one |
| `Last harvested` | stamped on all 5 — clean sweeps only; a run with errors deliberately leaves it stale |
| **Queue ceiling in batch** | `--queue-ceiling 10` against 16 Queued halted the run, named all 5 unswept channels, exit 1, spent nothing on Apify |
| Duplicates / forks | Videos 94 -> 106, Channels stayed **88**; zero duplicate keys; zero UC-keyed rows |
| **Invariant 3** | `eOebZr3BwSg` stayed `Declined` and `hFlBYtI7q7o` stayed `Done` through metric updates |

## Known limitations

- **No metrics history.** Values are overwritten in place with only `Metrics Captured At` to date
  them — you can see velocity now, not a trend. A snapshot table is the upgrade path; deliberately
  not built.
- **Formula display precision is UI-only.** `create_field` returns `precision: 0` and
  `update_field` accepts only `options.formula`. Verified display-only: the API returns exact values
  (`11.5`, `4.35`). Two clicks in the Airtable UI if the grid needs decimals.
- **No backfill** of the extension-captured videos. Note this partially self-heals: a re-swept
  channel updates any of its videos still inside `--oldest-post-date`, which is how `hFlBYtI7q7o`
  (a `Done` record from 2026-07-11) gained metrics without being re-created.

## Operational note

This run took Queued from 4 to 16 against a ceiling of 30 — real intake against the human review
gate, which is the actual bottleneck. Five channels were ticked for `Harvest?`
(`@WayneStLedger`, `@M365CopilotConnection`, `@MicrosoftCommunityLearning`, `@KevinStratvert`,
`@your365coach`); adjust by ticking/unticking in Airtable, no commit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
