### PR TITLE
ci: agentic TDD proof + minimal GitHub check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## What changed and why
+
+<!-- One or two sentences. Link the issue if there is one. -->
+
+---
+
+## TDD evidence
+
+See `docs/TDD-CONTRACT.md`. Fill all four — never leave one blank.
+
+### RED
+
+<!-- The test written first, and the ACTUAL failure output. Paste it. -->
+
+```
+```
+
+### GREEN
+
+<!-- The same focused test passing after the implementation. -->
+
+```
+```
+
+### REGRESSION
+
+<!-- `npm run check` fully green — both suites. -->
+
+```
+```
+
+### LIVE
+
+<!--
+Airtable/Apify verification, or an explicit "not applicable" with the reason.
+"Not applicable" is correct and expected for anything that does not reach Apify or Airtable.
+
+If it DOES reach them, confirm:
+  - Videos queried by `Video ID` — exactly one record (invariant 4)
+  - Channels did not fork — one row, `@handle` form, not `UC...`
+  - `Triage Status` and `Track` untouched on update (invariant 3)
+-->
+
+---
+
+- [ ] No credentials, tokens, or `secrets.` references added to CI

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,32 @@
+name: check
+
+# Pull requests, plus pushes to master. Scoping `push` to master is deliberate:
+# `on: push` unscoped would double-run for same-repo PR branches, producing two
+# runs per push where the point is one clear green/red check.
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: chrome-extension/package-lock.json
+
+      # `npm ci` only in chrome-extension — it is the only package with a
+      # lockfile, and normalizer has no dependencies at all.
+      - run: npm run setup
+
+      # No `env:` block and no `secrets.` reference, on purpose. Both suites are
+      # hermetic: airtable-client.test.js stubs globalThis.fetch and nothing
+      # reads process.env. CI verifies RED/GREEN/REGRESSION; LIVE verification
+      # against Airtable and Apify is a human-reviewed attestation, never a job
+      # here. See docs/TDD-CONTRACT.md.
+      - run: npm run check

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ storyboard_output_*/
 gh[0-9]*.txt
 pipeline-server/node_modules/
 chrome-extension/node_modules/
+node_modules/
 
 # Spyder project settings
 .spyderproject

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ left in this repo is mostly *not* "capture more," it's making what's captured ea
 
 | Path | Status |
 |------|--------|
-| Apify `streamers/youtube-scraper` (`h7sDV53CddomktSi5`) | **Primary — working end to end**, verified live 2026-07-29, extended to metrics + batch sweeps 2026-07-30 (branch `feat/metrics-fields`) |
+| Apify `streamers/youtube-scraper` (`h7sDV53CddomktSi5`) | **Primary — working end to end**, verified live 2026-07-29, extended to metrics + batch sweeps 2026-07-30, merged to `master` via PR #69 |
 | Chrome extension (`chrome-extension/`) | **Frozen fallback** — works, no further investment |
 | YouTube Data API v3 | Permanently closed — ownership dealbreaker |
 | Direct HTTP / `timedtext` from our own IP | Permanently closed — 429 `IpBlocked` |
@@ -88,11 +88,14 @@ refinery's real bottleneck is a human review gate). All shipped except the last:
 - ✅ `Intake Source` on Videos — hand-curated (`Watch Later`) vs swept (`Sweep`), so triage can be
   stricter on sweeps. Everything triaged before 2026-07-30 was hand-picked; that's no longer true.
 - ✅ Queue-depth ceiling, **re-checked before each channel** in batch mode.
-- ⬜ A **Track-unset** view on Channels. Bulk ingest creates Channels with blank `Track`, and the
-  refinery's working view filters `Track = AIHS OR Tooling-watch` — so blank-Track videos vanish
-  *silently* rather than failing loudly. **4 of 88 Channels** are currently blank
-  (`@Jasper_Tech`, `@BulbDigital`, `@3.7Million`, `@WizardsandWarriors`). Manual UI step — the
-  Airtable MCP has no create-view tool.
+- ✅ A blank-`Track` guard. Bulk ingest creates Channels with blank `Track`, and the refinery's
+  working view filters `Track = AIHS OR Tooling-watch` — so blank-Track videos vanish *silently*
+  rather than failing loudly. Shipped as a repo-side audit command, `normalizer/audit.js`, rather
+  than a manual Airtable view (the Airtable MCP has no create-view tool, so a view would need
+  manual UI upkeep with nothing to catch drift). Run `cd normalizer && node audit.js` — it also
+  checks for `Harvest?`-ticked channels with no `Source URL`, Videos with no Channel link,
+  duplicate `Video ID`s, and Videos missing `Metrics Captured At`. **4 of 88 Channels** are
+  currently blank-`Track` (`@Jasper_Tech`, `@BulbDigital`, `@3.7Million`, `@WizardsandWarriors`).
 
 ### Where things stand, and what's actually next
 
@@ -103,10 +106,14 @@ Live counts as of 2026-07-30: **106 Videos** (16 `Queued`, ceiling 30), **88 Cha
 1. **Triage the 16 Queued** before sweeping more — the ceiling will halt a batch partway at 30, by
    design. This is the bottleneck; adding capture volume against it is the one move that makes
    things worse.
-2. Build the Track-unset view (above).
-3. Decide unattended invocation — cron, a scheduled task, or stay manual. `--from-airtable` makes
-   this a single command with no channel list baked into the repo, so nothing blocks it technically.
-   The question is whether *capture* should be automated while triage isn't.
+2. Run `node normalizer/audit.js` (above) periodically to catch drift — it's read-only and cheap.
+3. **Unattended invocation stays manual (decided 2026-07-30).** `--from-airtable` makes it
+   technically a single command with no channel list baked into the repo, but capture is not the
+   real constraint — the AIHS refinery has spawned Ideas from only 5 of 106 captured videos, and
+   published 0 of 27 Ideas ever created. Automating the cheap, working end of the pipe while the
+   downstream review gate stays a bottleneck just piles up unreviewed ore faster. See the pipeline
+   redesign doc, `~/claude/Youtube Transcripts/_meta/SPEC-pipeline-redesign-2026-07-30.md`
+   (pointer: `docs/PIPELINE-REDESIGN.md`), before revisiting this.
 
 Actor input keys (verified 2026-07-29 against the published schema and two live channel-mode runs):
 `startUrls`, `maxResults`, `maxResultsShorts`, `maxResultStreams`, `oldestPostDate`, `dateFilter`,
@@ -149,7 +156,10 @@ correction.
    both finders throw and name the colliding ids rather than silently writing to `records[0]`, which
    is what both it and `background.js` used to do. (`Video ID oTphk2SVHNc` was in exactly this state
    until 2026-07-29; the two records held identical transcripts but disjoint links — 25 Shots on one,
-   the Channel link and provenance on the other — so they were merged, not parked.)
+   the Channel link and provenance on the other. **Corrected 2026-07-30**: live state shows it was
+   *parked*, not merged — `reca4ffDtP8QDoFqt` still exists with `Video ID` mangled to
+   `oTphk2SVHNc-DUP` so it can't re-collide. See "known base state" in
+   `docs/NORMALIZER-MANIFEST.md` for the full list of parked/junk records.)
 3. **Never touch `Triage Status` on update.** Set `Queued` on create only. The Channels analogue is
    **`Track`**: `upsertChannel` now PATCHes stats onto existing rows, and it must never write
    `Track`. Both are human-owned routing, and both fail silently — a clobbered `Track` drops the
@@ -192,10 +202,11 @@ chrome-extension/          # the frozen fallback — Manifest V3, vanilla JS, no
 └── icons/                 #   placeholders only; no store publish
 normalizer/                # the primary path — Apify -> Airtable, Node, no deps
 ├── apify-harvest.js       #   CLI: arg guardrails, per-channel ceiling re-check, dry-run
+├── audit.js               #   read-only base health check — blank Track, orphans, dupes, stale metrics
 ├── lib/apify-client.js    #   actor run + dataset fetch
 ├── lib/srt-parser.js      #   subtitles -> {text, start}
 ├── lib/transform.js       #   dataset item -> {createOnlyFields, updateFields, channel}
-└── lib/airtable-client.js #   upsert by Video ID, find-or-create Channel
+└── lib/airtable-client.js #   upsert by Video ID, find-or-create Channel, listAll* for audit.js
 docs/TDD-CONTRACT.md       # the one command + the four evidence lines — READ THIS FIRST
 docs/NORMALIZER-MANIFEST.md# normalizer design + live verification tables
 docs/archive/              # FINDINGS-youtube-automation.md — five months of hard-won facts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,8 @@ Live counts as of 2026-07-30: **106 Videos** (16 `Queued`, ceiling 30), **88 Cha
 1. **Triage the 16 Queued** before sweeping more — the ceiling will halt a batch partway at 30, by
    design. This is the bottleneck; adding capture volume against it is the one move that makes
    things worse.
-2. **Commit `feat/metrics-fields`** — the metrics/batch work is verified live but was left
-   uncommitted.
-3. Build the Track-unset view (above).
-4. Decide unattended invocation — cron, a scheduled task, or stay manual. `--from-airtable` makes
+2. Build the Track-unset view (above).
+3. Decide unattended invocation — cron, a scheduled task, or stay manual. `--from-airtable` makes
    this a single command with no channel list baked into the repo, so nothing blocks it technically.
    The question is whether *capture* should be automated while triage isn't.
 
@@ -192,11 +190,32 @@ chrome-extension/          # the frozen fallback — Manifest V3, vanilla JS, no
 ├── lib/transcript-utils.js#   GH-64 truncation shim — REUSE THIS in the normalizer
 ├── popup.*  settings.*    #   manual UI + credential entry
 └── icons/                 #   placeholders only; no store publish
+normalizer/                # the primary path — Apify -> Airtable, Node, no deps
+├── apify-harvest.js       #   CLI: arg guardrails, per-channel ceiling re-check, dry-run
+├── lib/apify-client.js    #   actor run + dataset fetch
+├── lib/srt-parser.js      #   subtitles -> {text, start}
+├── lib/transform.js       #   dataset item -> {createOnlyFields, updateFields, channel}
+└── lib/airtable-client.js #   upsert by Video ID, find-or-create Channel
+docs/TDD-CONTRACT.md       # the one command + the four evidence lines — READ THIS FIRST
+docs/NORMALIZER-MANIFEST.md# normalizer design + live verification tables
 docs/archive/              # FINDINGS-youtube-automation.md — five months of hard-won facts
-.claude/skills/            # diagnose-stuck-automation (general-purpose, kept)
+.github/workflows/check.yml# CI: runs `npm run check`, no credentials, ever
+.claude/skills/            # apify-harvest, diagnose-stuck-automation
 ```
 
-Tests: `cd chrome-extension && npm test`.
+## How work gets done here
+
+One command, from the repo root:
+
+```bash
+npm run setup   # once per clone
+npm run check   # both suites — chrome-extension, then normalizer
+```
+
+Every change reports four lines of evidence — **RED**, **GREEN**, **REGRESSION**, **LIVE** (or an
+explicit "not applicable"). The contract, what LIVE actually requires, and why there is deliberately
+no pre-commit hook: `docs/TDD-CONTRACT.md`. GitHub re-runs `npm run check` on every pull request,
+with no credentials — so it verifies the first three and never the fourth.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 Captures YouTube transcripts and video metadata into Airtable, feeding the AIHS content refinery.
 
-**Status (2026-07-29):** capture is pivoting from browser automation to a hosted scraper (Apify).
-The Chrome extension still works and is kept as a manual fallback; it is no longer being developed.
+**Status (2026-07-30):** the pivot from browser automation to a hosted scraper is complete. The Apify
+normalizer is the primary capture path, proven end to end 2026-07-29 and extended to metrics and
+batch sweeps 2026-07-30. The Chrome extension still works and is kept as a manual fallback; it is no
+longer being developed.
 
 > Formerly a shot-list / storyboard pipeline (ComfyUI, frame capture, scene analysis). All of that was
 > removed on 2026-07-29 and is recoverable from git history. See `CLAUDE.md`.
@@ -11,12 +13,61 @@ The Chrome extension still works and is kept as a manual fallback; it is no long
 ## Layout
 
 ```
+normalizer/          Apify → Airtable normalizer (Node, no deps) — the primary capture path
 chrome-extension/    Manifest V3 extension — the manual fallback capture path
+docs/TDD-CONTRACT.md One command, four lines of evidence — read before changing anything
+docs/NORMALIZER-MANIFEST.md  normalizer design + live verification tables
 docs/archive/        FINDINGS-youtube-automation.md — why capture works the way it does
-.claude/skills/      diagnose-stuck-automation
+.github/workflows/   check.yml — runs `npm run check`, no credentials
+.claude/skills/      apify-harvest, diagnose-stuck-automation
 ```
 
-## Chrome extension (manual capture)
+## Development
+
+One command, from the repo root:
+
+```bash
+npm run setup
+```
+
+```bash
+npm run check
+```
+
+`setup` runs once per clone (it installs `jsdom`, the extension suite's only dependency). `check`
+runs both suites — `chrome-extension` then `normalizer` — and is what GitHub re-runs on every pull
+request.
+
+Every change reports **RED / GREEN / REGRESSION / LIVE** evidence in its pull request. See
+[docs/TDD-CONTRACT.md](docs/TDD-CONTRACT.md) for what each means, when LIVE is legitimately "not
+applicable", and why there is deliberately no pre-commit hook.
+
+## Apify capture (primary)
+
+Actor: `streamers/youtube-scraper` (`h7sDV53CddomktSi5`), pay-per-event at ~$0.004/video. The Node
+normalizer maps dataset items to Airtable, reusing `chrome-extension/lib/transcript-utils.js` for
+GH-64 truncation.
+
+One channel:
+
+```bash
+cd normalizer && node apify-harvest.js --channel-url https://www.youtube.com/@SomeChannel --max-results 5 --oldest-post-date 2026-07-01 --dry-run
+```
+
+Every channel with `Harvest?` ticked in Airtable, using each row's `Source URL`:
+
+```bash
+cd normalizer && node apify-harvest.js --from-airtable --max-results 5 --oldest-post-date "30 days"
+```
+
+`--max-results` and `--oldest-post-date` are **mandatory in both modes**, dry-run or not — batch
+multiplies the cost by the channel count. Note a `--dry-run` still runs the actor and still costs the
+same; it is for checking the payload, not for saving money.
+
+Design, guardrails, the write invariants it must honour, and the live verification tables:
+`CLAUDE.md` and [docs/NORMALIZER-MANIFEST.md](docs/NORMALIZER-MANIFEST.md).
+
+## Chrome extension (manual fallback)
 
 1. Load unpacked at `chrome://extensions/` → point it at `chrome-extension/`.
 2. Open its Settings page and enter your Airtable API key + Base ID (stored in
@@ -25,18 +76,7 @@ docs/archive/        FINDINGS-youtube-automation.md — why capture works the wa
 4. **Verify the write in Airtable by `Video ID`.** The panel's status is not authoritative — a
    reported error can be a false negative after a successful save.
 
-No build step, vanilla JS. Tests:
-
-```bash
-cd chrome-extension && npm test
-```
-
-## Apify capture (in progress)
-
-Not built yet. Actor: `streamers/youtube-scraper` (`h7sDV53CddomktSi5`), pay-per-event at
-~$0.004/video. A Node normalizer in this repo will map dataset items to Airtable, reusing
-`chrome-extension/lib/transcript-utils.js` for GH-64 truncation. Design, guardrails and the write
-invariants it must honour are in `CLAUDE.md`.
+No build step, vanilla JS.
 
 ## Before changing how transcripts are captured
 
@@ -46,5 +86,5 @@ were established empirically here, and the second was accidentally re-proposed m
 
 ## Environment
 
-`.env` (not committed): `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID`, and `APIFY_TOKEN` once the normalizer
-lands.
+`.env` (not committed): `AIRTABLE_API_KEY`, `AIRTABLE_BASE_ID`, `APIFY_TOKEN`. CI needs none of
+these and is never given them.

--- a/docs/NORMALIZER-MANIFEST.md
+++ b/docs/NORMALIZER-MANIFEST.md
@@ -116,6 +116,23 @@ Airtable schema change already applied live (not just in code): `Videos` has a n
 Source` singleSelect field (`fldmKbQYo8YoMWMT4`, options `Watch Later` / `Sweep`) — the guardrail
 CLAUDE.md called for, to let triage be stricter on unattended-sweep videos.
 
+## Known base state — don't re-discover these as defects
+
+Confirmed live 2026-07-30 via `node normalizer/audit.js`. The mangled `Video ID` values on the
+first two can't collide with a real upsert, so these are documented deliberately, not deleted.
+
+| Record | State |
+|---|---|
+| `reca4ffDtP8QDoFqt` | tombstone, `Video ID = oTphk2SVHNc-DUP`, `Triage Status = Done` — parked duplicate of `oTphk2SVHNc`, not merged (see CLAUDE.md write invariant 2) |
+| `recRYJ0UzWJ3YBrzk` | tombstone, `Video ID = V22VtQ916Y0-DUP-declined`, `Triage Status = Declined` |
+| `recLhZak5ARNtgYbE` | completely empty record — no title, no Video ID, no status |
+| `recRlmmrTXdGxFNTb` | stub — has `Video ID = 6KktB5aNrjE`, no title, no Triage Status |
+
+The audit also surfaces two *real* Videos with no Channel link — `I4kGV5sJEdA` and `ib74sLgjIBM`,
+both `Triage Status = Done`. Not junk (real titles, real status), just orphaned from their Channel
+link somehow. Not investigated as part of the 2026-07-30 pass; `audit.js` will keep surfacing them
+until fixed or explicitly noted here as accepted.
+
 ## Verified facts about the Apify actor (streamers/youtube-scraper, h7sDV53CddomktSi5)
 
 Confirmed via two real single-video probe runs (`https://www.youtube.com/watch?v=qdRw7oHDXJw`,
@@ -227,7 +244,9 @@ What remains:
    constraint is not capture any more: it's the human review gate downstream (see the queue
    ceiling, and item 5).
 
-4. ~~Merge `feat/apify-normalizer`~~ — **done** (`3a878d1`). `feat/metrics-fields` is the open one.
+4. ~~Merge `feat/apify-normalizer`~~ — **done** (`3a878d1`). ~~Merge `feat/metrics-fields`~~ — **done**
+   (PR #69, `ce91b57`). Work since the merge lives on `feat/tdd-ci`: a TDD contract + CI check
+   (`349c84b`) and the `normalizer/audit.js` command (2026-07-30, this session).
 
 5. Not this normalizer's job, but adjacent and worth remembering: the receiving-end refinery
    (`~/claude/Youtube Transcripts`) still has its own gate closed — "Still gated until treatment

--- a/docs/PIPELINE-REDESIGN.md
+++ b/docs/PIPELINE-REDESIGN.md
@@ -1,0 +1,11 @@
+# Pipeline redesign — pointer
+
+The design doc for redesigning the pipeline around published output (not more capture) lives in the
+refinery repo, since it spans both projects and the Airtable base is the shared spine:
+
+`~/claude/Youtube Transcripts/_meta/SPEC-pipeline-redesign-2026-07-30.md`
+
+Written 2026-07-30. Covers: the measured capture→published funnel (106 videos → 5 ever spawned an
+Idea → 27 Ideas → 0 published), the three reasons the funnel breaks, a target architecture designed
+backwards from a published piece, a kill list, and four open questions for Thaddius (destination,
+cadence, the two-record model, the teardown/digest fork).

--- a/docs/TDD-CONTRACT.md
+++ b/docs/TDD-CONTRACT.md
@@ -1,0 +1,74 @@
+# TDD contract
+
+Every change to this repo — human or agent — runs one command and reports four lines of evidence.
+That is the whole contract. It exists so a claim like "tests pass" is falsifiable: GitHub re-runs the
+same command on every pull request, and the human reviews the evidence instead of supervising each
+step.
+
+## The one command
+
+```bash
+npm run setup   # once per clone — installs chrome-extension's only dep, jsdom
+npm run check   # both suites: chrome-extension, then normalizer
+```
+
+`check` runs tests only, so it is fast to re-run inside a red/green loop. It fails fast: if the
+extension suite goes red, the normalizer suite does not run. That is deliberate — one clear red.
+
+For a tight loop on one file, `node --test <path>` is fine; `npm run check` is what counts as
+regression evidence.
+
+## The four evidence lines
+
+Report all four in the pull request. The template gives you the boxes.
+
+- **RED** — the test you wrote first, and the *actual* failure output. Not "it failed" — paste it.
+  A test that has never been observed failing is not evidence that it tests anything.
+- **GREEN** — the same focused test passing after the implementation.
+- **REGRESSION** — `npm run check` fully green. Both suites.
+- **LIVE** — Airtable/Apify verification, **or an explicit "not applicable."** Never blank.
+
+## What LIVE means, and when it is "not applicable"
+
+Unit tests here are hermetic by construction: `normalizer/lib/airtable-client.test.js` stubs
+`globalThis.fetch`, and nothing in either suite reads `process.env` or touches the network. Green
+tests therefore prove the code matches *our model* of Airtable and Apify — not that the model is
+right. LIVE is where you check the model.
+
+When the change touches the Apify → Airtable path, LIVE means the verification in
+`.claude/skills/apify-harvest/SKILL.md` and the write invariants in `CLAUDE.md`:
+
+- Query Videos by `Video ID` and confirm exactly one record — a reported `error` can be a false
+  negative after a successful save (invariant 4; a misread status flag caused a duplicate on
+  2026-07-26).
+- Confirm Channels did not fork: one row per channel, `Channel Handle` in `@handle` form, never
+  `UC...`.
+- Confirm `Triage Status` and `Track` were not touched on update (invariant 3).
+
+**"Not applicable" is the correct and expected answer for most changes** — anything that does not
+reach Apify or Airtable. Say so explicitly rather than leaving the box empty.
+
+**LIVE is not free.** A `--dry-run` still runs the actor and still costs roughly $0.004/video. Do not
+reach for a live run to satisfy a checkbox.
+
+## What CI does and does not do
+
+`.github/workflows/check.yml` runs `npm run check` on pull requests and on pushes to `master`. It has
+**no `AIRTABLE_API_KEY`, no `AIRTABLE_BASE_ID`, no `APIFY_TOKEN`, and no `secrets.` reference at
+all** — and it should stay that way. CI verifies RED, GREEN, and REGRESSION. It cannot verify LIVE,
+which is why LIVE is an attestation the human spot-checks.
+
+There is deliberately **no pre-commit hook.** TDD has a red stage; a hook that blocks every commit
+containing a failing test fights the process. The gate runs before push and in GitHub instead.
+
+## Filing the pull request
+
+`gh pr create --body "..."` **silently ignores** `.github/pull_request_template.md`. Use
+`--body-file`, or the prefilled editor, or paste the four boxes yourself.
+
+## Rules this contract does not restate
+
+- Airtable write invariants — `CLAUDE.md`, "Write invariants". Read them before touching
+  `normalizer/lib/`.
+- Harvest verification and the error playbook — `.claude/skills/apify-harvest/SKILL.md`.
+- Why capture works the way it does — `docs/archive/FINDINGS-youtube-automation.md` §1.

--- a/normalizer/apify-harvest.js
+++ b/normalizer/apify-harvest.js
@@ -35,12 +35,24 @@ const {
   upsertVideo,
 } = require('./lib/airtable-client');
 
+// Parse .env text into { KEY: value }. Pure, so it is testable without
+// touching the real .env sitting one directory up.
+function parseDotEnv(text) {
+  const values = {};
+  for (const line of String(text).split('\n')) {
+    const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line.trim());
+    if (match) values[match[1]] = match[2];
+  }
+  return values;
+}
+
+// Not overriding an already-set variable is the wrapper's job, not the
+// parser's: a real environment beats a file on disk.
 function loadDotEnv() {
   const envPath = path.join(__dirname, '..', '.env');
   if (!fs.existsSync(envPath)) return;
-  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
-    const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line.trim());
-    if (match && !process.env[match[1]]) process.env[match[1]] = match[2];
+  for (const [key, value] of Object.entries(parseDotEnv(fs.readFileSync(envPath, 'utf8')))) {
+    if (!process.env[key]) process.env[key] = value;
   }
 }
 
@@ -369,4 +381,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { parseArgs, validateArgs, elideTranscripts, USAGE };
+module.exports = { parseArgs, parseDotEnv, validateArgs, elideTranscripts, USAGE };

--- a/normalizer/apify-harvest.js
+++ b/normalizer/apify-harvest.js
@@ -41,9 +41,18 @@ function parseDotEnv(text) {
   const values = {};
   for (const line of String(text).split('\n')) {
     const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line.trim());
-    if (match) values[match[1]] = match[2];
+    if (match) values[match[1]] = unquote(match[2]);
   }
   return values;
+}
+
+// Strip one MATCHED pair of surrounding quotes, and nothing else. A lone
+// leading quote is part of the value, not a quote — eating it would silently
+// corrupt a real secret, which is the failure this function exists to avoid.
+function unquote(value) {
+  const quoted = /^"(.*)"$|^'(.*)'$/s.exec(value);
+  if (!quoted) return value;
+  return quoted[1] !== undefined ? quoted[1] : quoted[2];
 }
 
 // Not overriding an already-set variable is the wrapper's job, not the

--- a/normalizer/apify-harvest.test.js
+++ b/normalizer/apify-harvest.test.js
@@ -1,7 +1,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { parseArgs, validateArgs, elideTranscripts } = require('./apify-harvest');
+const { parseArgs, parseDotEnv, validateArgs, elideTranscripts } = require('./apify-harvest');
 
 const REQUIRED = ['--channel-url', 'https://www.youtube.com/@X', '--max-results', '2', '--oldest-post-date', '2026-01-01'];
 
@@ -83,6 +83,51 @@ test('validateArgs rejects a zero, negative, or non-numeric --max-results', () =
 
 test('validateArgs passes on a complete arg set', () => {
   assert.doesNotThrow(() => validateArgs(parseArgs(REQUIRED)));
+});
+
+// --- .env parsing -----------------------------------------------------------
+//
+// Quoting a value in .env is ordinary — most .env documentation shows it, and
+// anything pasted from a shell export arrives quoted. A parser that keeps the
+// quotes hands Airtable `"patXXX"` and gets a 401, which reads as a bad token
+// rather than a bad parse. That is a long way to walk for a stray character.
+
+test('parseDotEnv reads a bare KEY=value line', () => {
+  assert.deepEqual(parseDotEnv('AIRTABLE_BASE_ID=appWSbpJAxjCyLfrZ'), {
+    AIRTABLE_BASE_ID: 'appWSbpJAxjCyLfrZ',
+  });
+});
+
+test('parseDotEnv strips surrounding double quotes', () => {
+  assert.deepEqual(parseDotEnv('AIRTABLE_API_KEY="patXXX"'), { AIRTABLE_API_KEY: 'patXXX' });
+});
+
+test('parseDotEnv strips surrounding single quotes', () => {
+  assert.deepEqual(parseDotEnv("APIFY_TOKEN='apify_api_XXX'"), { APIFY_TOKEN: 'apify_api_XXX' });
+});
+
+test('parseDotEnv leaves an unmatched quote alone rather than guessing', () => {
+  // Only a matched pair is a quote. `"oops` is a value that starts with a
+  // quote character, and silently eating it would corrupt a real secret.
+  assert.deepEqual(parseDotEnv('APIFY_TOKEN="oops'), { APIFY_TOKEN: '"oops' });
+  assert.deepEqual(parseDotEnv('APIFY_TOKEN=\'mixed"'), { APIFY_TOKEN: '\'mixed"' });
+});
+
+test('parseDotEnv keeps quotes that are inside the value', () => {
+  assert.deepEqual(parseDotEnv('APIFY_TOKEN=a"b"c'), { APIFY_TOKEN: 'a"b"c' });
+});
+
+test('parseDotEnv keeps an "=" that appears inside the value', () => {
+  assert.deepEqual(parseDotEnv('AIRTABLE_API_KEY=pat.a=b=c'), { AIRTABLE_API_KEY: 'pat.a=b=c' });
+});
+
+test('parseDotEnv ignores comments, blank lines, and lowercase keys', () => {
+  const text = ['# a comment', '', '   ', 'lowercase=ignored', 'APIFY_TOKEN=t'].join('\n');
+  assert.deepEqual(parseDotEnv(text), { APIFY_TOKEN: 't' });
+});
+
+test('parseDotEnv reads an empty value as an empty string', () => {
+  assert.deepEqual(parseDotEnv('APIFY_TOKEN='), { APIFY_TOKEN: '' });
 });
 
 test('elideTranscripts summarises long values but keeps short ones intact', () => {

--- a/normalizer/audit.js
+++ b/normalizer/audit.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Read-only base audit. Separate from apify-harvest.js because that CLI makes
+// --max-results/--oldest-post-date mandatory as a capture guardrail, and
+// those are meaningless for a check that performs zero writes.
+//
+//   node audit.js
+//
+// Exits non-zero if any check finds something. Every finding is printed with
+// enough detail to act on directly (handle, record id, video id) — see
+// CLAUDE.md "Active work" item 3 for why this replaces a manual Airtable view.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { listAllChannels, listAllVideos } = require('./lib/airtable-client');
+
+function loadDotEnv() {
+  const envPath = path.join(__dirname, '..', '.env');
+  if (!fs.existsSync(envPath)) return;
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line.trim());
+    if (match && !process.env[match[1]]) process.env[match[1]] = match[2];
+  }
+}
+
+// Each check takes the already-fetched channels/videos and returns an array
+// of finding strings (empty = clean). Pure functions so they're testable
+// without touching the network.
+
+function findBlankTrackChannels(channels) {
+  return channels
+    .filter((c) => !c.track)
+    .map((c) => `${c.handle || '(no handle)'} — "${c.channelName}" (${c.recordId})`);
+}
+
+function findMisconfiguredHarvestChannels(channels) {
+  return channels
+    .filter((c) => c.harvest && !c.sourceUrl)
+    .map((c) => `${c.handle || '(no handle)'} — "${c.channelName}" (${c.recordId})`);
+}
+
+function findVideosWithNoChannel(videos) {
+  return videos
+    .filter((v) => !v.channelLinks || v.channelLinks.length === 0)
+    .map((v) => `${v.videoId || '(no Video ID)'} — "${v.title}" (${v.recordId})`);
+}
+
+function findDuplicateVideoIds(videos) {
+  const byId = new Map();
+  for (const v of videos) {
+    if (!v.videoId) continue;
+    if (!byId.has(v.videoId)) byId.set(v.videoId, []);
+    byId.get(v.videoId).push(v.recordId);
+  }
+  const dupes = [];
+  for (const [videoId, recordIds] of byId) {
+    if (recordIds.length > 1) dupes.push(`${videoId} — ${recordIds.join(', ')}`);
+  }
+  return dupes;
+}
+
+// Metrics only ever land via a sweep (see updateFields in transform.js), so a
+// Queued video whose channel isn't Harvest?-ticked is stuck metrics-less
+// until someone ticks it — this is expected, not a bug, but worth surfacing.
+function findVideosMissingMetrics(videos) {
+  return videos
+    .filter((v) => !v.metricsCapturedAt)
+    .map((v) => `${v.videoId || '(no Video ID)'} — "${v.title}" (${v.triageStatus || 'no status'})`);
+}
+
+const CHECKS = [
+  {
+    label: 'Blank Track Channels',
+    hint: 'silently vanish from the working view (Track = AIHS OR Tooling-watch)',
+    run: (data) => findBlankTrackChannels(data.channels),
+  },
+  {
+    label: 'Harvest? ticked with no Source URL',
+    hint: 'skipped by --from-airtable at sweep time; fix the row before the next sweep',
+    run: (data) => findMisconfiguredHarvestChannels(data.channels),
+  },
+  {
+    label: 'Videos with no Channel link',
+    hint: 'orphaned records — Channel-Track lookups and Track routing can\'t reach them',
+    run: (data) => findVideosWithNoChannel(data.videos),
+  },
+  {
+    label: 'Duplicate Video ID values',
+    hint: 'breaks upsert-by-key — merge or park the extras (write invariant 2)',
+    run: (data) => findDuplicateVideoIds(data.videos),
+  },
+  {
+    label: 'Videos missing Metrics Captured At',
+    hint: 're-sweep is the only metrics-refresh mechanism — expected for videos whose channel isn\'t Harvest?-ticked',
+    run: (data) => findVideosMissingMetrics(data.videos),
+  },
+];
+
+async function runAudit(apiKey, baseId) {
+  const [channels, videos] = await Promise.all([
+    listAllChannels(apiKey, baseId),
+    listAllVideos(apiKey, baseId),
+  ]);
+
+  const results = CHECKS.map((check) => ({
+    label: check.label,
+    hint: check.hint,
+    findings: check.run({ channels, videos }),
+  }));
+
+  return { channelCount: channels.length, videoCount: videos.length, results };
+}
+
+async function main() {
+  loadDotEnv();
+
+  const airtableKey = process.env.AIRTABLE_API_KEY;
+  const baseId = process.env.AIRTABLE_BASE_ID;
+  if (!airtableKey || !baseId) throw new Error('AIRTABLE_API_KEY / AIRTABLE_BASE_ID not set (.env)');
+
+  const { channelCount, videoCount, results } = await runAudit(airtableKey, baseId);
+  console.log(`[audit] ${channelCount} Channels, ${videoCount} Videos — read-only, no writes performed\n`);
+
+  let totalFindings = 0;
+  for (const { label, hint, findings } of results) {
+    totalFindings += findings.length;
+    if (findings.length === 0) {
+      console.log(`[ok] ${label}: none`);
+      continue;
+    }
+    console.warn(`[warn] ${label}: ${findings.length} — ${hint}`);
+    for (const finding of findings) console.warn(`         ${finding}`);
+  }
+
+  console.log(`\n[summary] ${totalFindings} finding(s) across ${results.length} check(s)`);
+  if (totalFindings > 0) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`\nError: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  runAudit,
+  findBlankTrackChannels,
+  findMisconfiguredHarvestChannels,
+  findVideosWithNoChannel,
+  findDuplicateVideoIds,
+  findVideosMissingMetrics,
+};

--- a/normalizer/audit.js
+++ b/normalizer/audit.js
@@ -13,13 +13,17 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { listAllChannels, listAllVideos } = require('./lib/airtable-client');
+const { parseDotEnv } = require('./apify-harvest');
 
+// Not overriding an already-set variable is this wrapper's job, not the
+// parser's: a real environment beats a file on disk. Reuses parseDotEnv
+// (apify-harvest.js) rather than re-parsing .env by hand, so a quoted value
+// unwraps here the same way it does for the harvest CLI.
 function loadDotEnv() {
   const envPath = path.join(__dirname, '..', '.env');
   if (!fs.existsSync(envPath)) return;
-  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
-    const match = /^([A-Z_][A-Z0-9_]*)=(.*)$/.exec(line.trim());
-    if (match && !process.env[match[1]]) process.env[match[1]] = match[2];
+  for (const [key, value] of Object.entries(parseDotEnv(fs.readFileSync(envPath, 'utf8')))) {
+    if (!process.env[key]) process.env[key] = value;
   }
 }
 

--- a/normalizer/audit.test.js
+++ b/normalizer/audit.test.js
@@ -1,0 +1,67 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  findBlankTrackChannels,
+  findMisconfiguredHarvestChannels,
+  findVideosWithNoChannel,
+  findDuplicateVideoIds,
+  findVideosMissingMetrics,
+} = require('./audit');
+
+test('findBlankTrackChannels reports only channels with no Track', () => {
+  const channels = [
+    { recordId: 'rec1', handle: '@A', channelName: 'A', track: 'AIHS' },
+    { recordId: 'rec2', handle: '@B', channelName: 'B', track: null },
+    { recordId: 'rec3', handle: '@C', channelName: 'C', track: '' },
+  ];
+  const findings = findBlankTrackChannels(channels);
+  assert.equal(findings.length, 2);
+  assert.match(findings[0], /@B/);
+  assert.match(findings[1], /@C/);
+});
+
+test('findMisconfiguredHarvestChannels reports Harvest? ticked with no Source URL', () => {
+  const channels = [
+    { recordId: 'rec1', handle: '@A', channelName: 'A', harvest: true, sourceUrl: 'https://x' },
+    { recordId: 'rec2', handle: '@B', channelName: 'B', harvest: true, sourceUrl: null },
+    { recordId: 'rec3', handle: '@C', channelName: 'C', harvest: false, sourceUrl: null },
+  ];
+  const findings = findMisconfiguredHarvestChannels(channels);
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /@B/);
+});
+
+test('findVideosWithNoChannel reports videos with an empty Channel link', () => {
+  const videos = [
+    { recordId: 'rec1', videoId: 'v1', title: 'T1', channelLinks: ['recChan'] },
+    { recordId: 'rec2', videoId: 'v2', title: 'T2', channelLinks: [] },
+    { recordId: 'rec3', videoId: 'v3', title: 'T3', channelLinks: null },
+  ];
+  const findings = findVideosWithNoChannel(videos);
+  assert.equal(findings.length, 2);
+  assert.match(findings[0], /v2/);
+  assert.match(findings[1], /v3/);
+});
+
+test('findDuplicateVideoIds reports only ids shared by more than one record', () => {
+  const videos = [
+    { recordId: 'rec1', videoId: 'dup' },
+    { recordId: 'rec2', videoId: 'dup' },
+    { recordId: 'rec3', videoId: 'unique' },
+    { recordId: 'rec4', videoId: null },
+  ];
+  const findings = findDuplicateVideoIds(videos);
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /dup — rec1, rec2/);
+});
+
+test('findVideosMissingMetrics reports videos with no Metrics Captured At', () => {
+  const videos = [
+    { recordId: 'rec1', videoId: 'v1', title: 'T1', triageStatus: 'Queued', metricsCapturedAt: '2026-07-30T00:00:00.000Z' },
+    { recordId: 'rec2', videoId: 'v2', title: 'T2', triageStatus: 'Queued', metricsCapturedAt: null },
+  ];
+  const findings = findVideosMissingMetrics(videos);
+  assert.equal(findings.length, 1);
+  assert.match(findings[0], /v2/);
+});

--- a/normalizer/lib/airtable-client.js
+++ b/normalizer/lib/airtable-client.js
@@ -108,6 +108,61 @@ async function listHarvestChannels(apiKey, baseId) {
   }));
 }
 
+// Read every record in a table, following Airtable's `offset` cursor.
+//
+// Distinct from countQueued/listHarvestChannels above, which deliberately read
+// only the first page — a ceiling check doesn't care whether it's 100 or 400,
+// and the harvest queue is a handful of ticked rows. An audit does care: it
+// reports absolute counts, and a silently-truncated read would under-report
+// exactly the problems it exists to find. Videos is already past one page.
+async function listAllRecords(apiKey, baseId, table, { fields = [] } = {}) {
+  const fieldParams = fields.map((f) => `fields%5B%5D=${encodeURIComponent(f)}`).join('&');
+  const records = [];
+  let offset;
+
+  do {
+    const query = [`pageSize=100`, fieldParams, offset ? `offset=${encodeURIComponent(offset)}` : '']
+      .filter(Boolean)
+      .join('&');
+    const result = await airtableRequest(apiKey, `${baseId}/${table}?${query}`);
+    records.push(...(result.records || []));
+    offset = result.offset;
+  } while (offset);
+
+  return records;
+}
+
+async function listAllChannels(apiKey, baseId) {
+  const records = await listAllRecords(apiKey, baseId, 'Channels', {
+    fields: ['Channel Handle', 'Channel Name', 'Track', 'Harvest?', 'Source URL', 'Last harvested'],
+  });
+  return records.map((record) => ({
+    recordId: record.id,
+    handle: record.fields['Channel Handle'] || null,
+    channelName: record.fields['Channel Name'] || '(unnamed)',
+    // Airtable returns singleSelect as a plain string on the REST API.
+    track: record.fields.Track || null,
+    harvest: Boolean(record.fields['Harvest?']),
+    sourceUrl: record.fields['Source URL'] || null,
+    lastHarvested: record.fields['Last harvested'] || null,
+  }));
+}
+
+async function listAllVideos(apiKey, baseId) {
+  const records = await listAllRecords(apiKey, baseId, 'Videos', {
+    fields: ['Video ID', 'Video Title', 'Triage Status', 'Intake Source', 'Channel', 'Metrics Captured At'],
+  });
+  return records.map((record) => ({
+    recordId: record.id,
+    videoId: record.fields['Video ID'] || null,
+    title: record.fields['Video Title'] || null,
+    triageStatus: record.fields['Triage Status'] || null,
+    intakeSource: record.fields['Intake Source'] || null,
+    channelLinks: record.fields.Channel || [],
+    metricsCapturedAt: record.fields['Metrics Captured At'] || null,
+  }));
+}
+
 // Find-or-create a Channel by Channel Handle.
 //
 // Looks up `handleKey` (@handle — what all existing rows use, see
@@ -201,6 +256,9 @@ module.exports = {
   countQueued,
   findVideoByVideoId,
   findChannelByHandle,
+  listAllChannels,
+  listAllRecords,
+  listAllVideos,
   listHarvestChannels,
   patchChannel,
   upsertChannel,

--- a/normalizer/lib/airtable-client.test.js
+++ b/normalizer/lib/airtable-client.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   findVideoByVideoId,
   findChannelByHandle,
+  listAllRecords,
   listHarvestChannels,
   upsertChannel,
   upsertVideo,
@@ -206,6 +207,36 @@ test('listHarvestChannels returns Harvest?-ticked rows with their Source URL', a
   // A ticked row with no Source URL is surfaced, not silently dropped here —
   // the CLI warns about it so the misconfiguration is visible.
   assert.equal(rows[1].sourceUrl, null);
+});
+
+// --- listAllRecords follows the offset cursor -------------------------------
+
+test('listAllRecords pages through offset until it runs out', async (t) => {
+  const pages = [
+    { records: [{ id: 'rec1' }, { id: 'rec2' }], offset: 'cursor1' },
+    { records: [{ id: 'rec3' }], offset: undefined },
+  ];
+  let call = 0;
+  const f = installFetch(() => pages[call++]);
+  t.after(f.restore);
+
+  const records = await listAllRecords(KEY, BASE, 'Videos', { fields: ['Video ID'] });
+
+  assert.deepEqual(records.map((r) => r.id), ['rec1', 'rec2', 'rec3']);
+  assert.equal(f.calls.length, 2);
+  assert.doesNotMatch(f.calls[0].url, /offset=/);
+  assert.match(f.calls[1].url, /offset=cursor1/);
+  assert.match(f.calls[0].url, /fields\[\]=Video ID/);
+});
+
+test('listAllRecords returns everything on a single page', async (t) => {
+  const f = installFetch(() => ({ records: [{ id: 'recOnly' }] }));
+  t.after(f.restore);
+
+  const records = await listAllRecords(KEY, BASE, 'Channels');
+
+  assert.equal(records.length, 1);
+  assert.equal(f.calls.length, 1);
 });
 
 // --- invariant 3: never touch Triage Status on update ----------------------

--- a/normalizer/package.json
+++ b/normalizer/package.json
@@ -5,6 +5,7 @@
   "description": "Apify streamers/youtube-scraper -> Airtable Videos normalizer for the AIHS transcript refinery",
   "scripts": {
     "test": "node --test",
-    "harvest": "node apify-harvest.js"
+    "harvest": "node apify-harvest.js",
+    "audit": "node audit.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "airtable-shots-db",
+  "version": "0.1.0",
+  "private": true,
+  "description": "YouTube transcript capture into Airtable — root task runner for the two test suites",
+  "scripts": {
+    "setup": "npm ci --prefix chrome-extension",
+    "check": "npm test --prefix chrome-extension && npm test --prefix normalizer"
+  }
+}


### PR DESCRIPTION
## What changed and why

First slice of #21. Four things, and nothing else:

1. **`npm run check`** — one root command running both suites. `npm run setup` is the one-time install; `check` stays install-free so it is fast to re-run inside a red/green loop.
2. **`docs/TDD-CONTRACT.md`** — RED / GREEN / REGRESSION / LIVE, pointing at `CLAUDE.md`'s write invariants and the `apify-harvest` skill rather than restating them.
3. **`.github/pull_request_template.md`** — fixed boxes for that evidence.
4. **`.github/workflows/check.yml`** — one job, Node 24, **no secrets and no `env:` block**.

Deliberately deferred: lint, format, Husky, Dependabot, coverage thresholds, reusable templates, branch protection. **No pre-commit hook** — TDD has a red stage, and a hook that blocks every commit containing a failing test fights the process. The gate runs before push and in GitHub instead.

### Corrections to the incoming spec

The slice as written contained four factual errors, all corrected here:

- **"All 57 existing tests pass"** — the real baseline is **78** (14 `chrome-extension` + 64 `normalizer`).
- **"Point to your existing framework rather than recreating it"** — there was no TDD framework to point at. `grep -ri tdd` across the repo returned nothing. The contract is written fresh, but kept short and referential.
- **`npm ci` cannot run in `normalizer/`** — it has no lockfile and no dependencies. `setup` installs `chrome-extension` only.
- **`on: push` unscoped would double-run** on same-repo PR branches, defeating "one clear check". `push` is scoped to `master`.

### Stale docs corrected

`README.md` said the Apify normalizer was **"Not built yet"** — it has been the primary capture path since 2026-07-29. Also fixed: the status line, the layout block (no `normalizer/`, no `apify-harvest` skill), and the `APIFY_TOKEN` note. `CLAUDE.md` still listed committing `feat/metrics-fields` as pending work after #69 merged it.

---

## TDD evidence

### RED

`loadDotEnv()` kept the quotes on a quoted `.env` value, so `AIRTABLE_API_KEY="patXXX"` reached Airtable as `"patXXX"` and came back 401 — which reads as a bad token rather than a bad parse. `parseDotEnv` was extracted with behaviour preserved exactly (b5cb131), so the failure isolates the bug and not a missing function.

```
✖ parseDotEnv strips surrounding double quotes (1.722375ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected

    {
  +   AIRTABLE_API_KEY: '"patXXX"'
  -   AIRTABLE_API_KEY: 'patXXX'
    }

ℹ tests 20
ℹ pass 18
ℹ fail 2
```

Six of the eight new tests passed on the red commit. That is deliberate — they are the regression guards for the fix: an unmatched quote must be left alone, quotes inside a value survive, an embedded `=` survives, comments and lowercase keys stay ignored, an empty value stays an empty string.

**GitHub independently confirmed the red** — run [30596980419](https://github.com/thaddiusatme/airtable-shots-db/actions/runs/30596980419) on b5cb131:

```
✖ parseDotEnv strips surrounding double quotes (3.591769ms)
✖ parseDotEnv strips surrounding single quotes (0.468644ms)
ℹ tests 72
ℹ pass 70
ℹ fail 2
##[error]Process completed with exit code 1.
```

The run immediately before it ([30596905645](https://github.com/thaddiusatme/airtable-shots-db/actions/runs/30596905645), infrastructure only) was **green**. The check flips in both directions, which is the actual claim being tested here.

### GREEN

Only a *matched* pair of quotes is stripped. A lone leading quote stays part of the value — eating it would silently corrupt a real secret, the same failure pointed the other way.

```
✔ parseDotEnv reads a bare KEY=value line
✔ parseDotEnv strips surrounding double quotes
✔ parseDotEnv strips surrounding single quotes
✔ parseDotEnv leaves an unmatched quote alone rather than guessing
✔ parseDotEnv keeps quotes that are inside the value
✔ parseDotEnv keeps an "=" that appears inside the value
✔ parseDotEnv ignores comments, blank lines, and lowercase keys
✔ parseDotEnv reads an empty value as an empty string
ℹ tests 20
ℹ pass 20
ℹ fail 0
```

### REGRESSION

`npm run check`, both suites — run [30597020487](https://github.com/thaddiusatme/airtable-shots-db/actions/runs/30597020487) on 2c5f337:

```
ℹ tests 14   ℹ pass 14   ℹ fail 0      (chrome-extension)
ℹ tests 72   ℹ pass 72   ℹ fail 0      (normalizer — 64 baseline + 8 new)
```

78 baseline + 8 new = **86, all green**.

The GitHub numbers are the authoritative ones. A local `npm run check` on this machine currently reports 79 normalizer tests, because a concurrent session has untracked audit work sitting in the working tree — a good illustration of why the remote check is the one that counts.

### LIVE

**Not applicable.** Nothing here reaches Apify or Airtable. `parseDotEnv` is a pure string function, and both suites are hermetic by construction (`airtable-client.test.js` stubs `globalThis.fetch`; nothing reads `process.env`) — which is also why CI needs no credentials.

Worth noting the fix makes a *previously broken* `.env` shape work rather than changing any working one: an unquoted `.env`, which is what this repo has, parses identically before and after.

---

- [x] No credentials, tokens, or `secrets.` references added to CI
